### PR TITLE
Add option to enable Point in time recovery for Vault's dynamodb table

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Two route53 records are provided to access the individual instances.
 | dynamodb_min_write_capacity | The min write capacity of the Vault dynamodb table | string | `5` | no |
 | dynamodb_table_name_override | Override Vault's DynamoDB table name with this variable. This module will generate a name if this is left empty (default behavior) | string | `` | no |
 | enable_dynamodb_autoscaling | Enables the autoscaling feature on the Vault dynamodb table | string | `true` | no |
+| enable_point_in_time_recovery | Whether to enable point-in-time recovery - note that it can take up to 10 minutes to enable for new tables. Note that additional charges will apply by enabling this setting (https://aws.amazon.com/dynamodb/pricing/) | string | `true` | no |
 | environment | Name of the environment where to deploy Vault (just for naming reasons) | string | - | yes |
 | instance_type | The instance type to use for the vault servers | string | `t2.micro` | no |
 | key_name | Name of the sshkey to deploy on the vault instances | string | - | yes |

--- a/vault/dynamodb.tf
+++ b/vault/dynamodb.tf
@@ -25,6 +25,10 @@ resource "aws_dynamodb_table" "vault_dynamodb_table" {
     Project     = "${var.project}"
   }
 
+  point_in_time_recovery {
+    enabled = "${var.enable_point_in_time_recovery}"
+  }
+
   lifecycle {
     ignore_changes = ["read_capacity", "write_capacity"]
   }

--- a/vault/variables.tf
+++ b/vault/variables.tf
@@ -123,3 +123,8 @@ variable "le_staging" {
 variable "le_email" {
   description = "The email address that's going to be used to register to LetsEncrypt"
 }
+
+variable "enable_point_in_time_recovery" {
+  description = "Whether to enable point-in-time recovery - note that it can take up to 10 minutes to enable for new tables. Note that additional charges will apply by enabling this setting (https://aws.amazon.com/dynamodb/pricing/)"
+  default     = true
+}


### PR DESCRIPTION
This covers the first feature described in https://github.com/skyscrapers/engineering/issues/56

More info on DynamoDB PITR: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/PointInTimeRecovery_Howitworks.html

Terraform changes on our Vault setup:

```
  ~ module.ha_vault.aws_dynamodb_table.vault_dynamodb_table
      point_in_time_recovery.0.enabled: "false" => "true"

  ~ module.ha_vault.aws_lb_target_group.vault1
      proxy_protocol_v2:                "" => "false"

  ~ module.ha_vault.aws_lb_target_group.vault2
      proxy_protocol_v2:                "" => "false"

  ~ module.ha_vault.module.alb.aws_alb_target_group.default
      proxy_protocol_v2:                "" => "false"

  ~ module.ha_vault.module.vault1.aws_instance.instance
      tags.%:                           "4" => "4"
      tags.Environment:                 "production" => "production"
      tags.Function:                    "vault1" => "vault1"
      tags.Name:                        "vault-production-vault1" => "vault-production-vault11"
      tags.Project:                     "vault" => "vault"

  ~ module.ha_vault.module.vault2.aws_instance.instance
      tags.%:                           "4" => "4"
      tags.Environment:                 "production" => "production"
      tags.Function:                    "vault2" => "vault2"
      tags.Name:                        "vault-production-vault2" => "vault-production-vault21"
      tags.Project:                     "vault" => "vault"
```

Only the first change is related to this PR, all the rest are probably caused by a new version of the AWS provider and a new version of the instance module.