### PR TITLE
Add option to enable DynamoDB global tables for Vault's backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Two route53 records are provided to access the individual instances.
 
 ### Terraform providers
 
-Because this module can be configured to setup a DynamoDB table in a separate region from the main table, it expects two Terraform providers: `aws` and `aws.replica`. If you want to enable the replica table, you'll need to create a second `aws` provider targeting the region you want to put the replica table on, and then pass it on to the module as `aws.replica`:
+Because this module can be configured to setup a DynamoDB table in a separate region from the main table, it expects two Terraform providers: `aws` and `aws.replica`. If you want to enable the replica table, you'll need to create a second `aws` provider targeting the region you want to put the replica table in, and then pass it on to the module as `aws.replica`:
 
 ```
 provider "aws" {
@@ -106,6 +106,8 @@ module "vault" {
 | alb_vault2_target_group | The vault2 target group ARN |
 | dynamodb_table_name | The Vault dynamodb table name |
 | iam_policy | The iam policy ARN used for vault |
+| main_dynamodb_table_region | Region where the main DynamoDB table will be created |
+| replica_dynamodb_table_region | Region where the replica DynamoDB table will be created, if enabled |
 | sg_id | The vault security-group id |
 | vault1_instance_id | The vault1 instance ID |
 | vault1_role_id | The vault1 instance-role ID |

--- a/dynamodb-table/main.tf
+++ b/dynamodb-table/main.tf
@@ -1,0 +1,92 @@
+locals {
+  dynamodb_table_name = "${var.dynamodb_table_name_override == "" ? format("vault-%s-%s", var.environment, var.project) : var.dynamodb_table_name_override}"
+}
+
+resource "aws_dynamodb_table" "vault_dynamodb_table" {
+  count            = "${var.enable ? 1 : 0}"
+  name             = "${local.dynamodb_table_name}"
+  read_capacity    = 5
+  write_capacity   = 5
+  hash_key         = "Path"
+  range_key        = "Key"
+  stream_enabled   = true
+  stream_view_type = "NEW_AND_OLD_IMAGES"
+
+  attribute {
+    name = "Key"
+    type = "S"
+  }
+
+  attribute {
+    name = "Path"
+    type = "S"
+  }
+
+  tags {
+    Name        = "${local.dynamodb_table_name}"
+    Environment = "${var.environment}"
+    Project     = "${var.project}"
+  }
+
+  point_in_time_recovery {
+    enabled = "${var.enable_point_in_time_recovery}"
+  }
+
+  lifecycle {
+    ignore_changes = ["read_capacity", "write_capacity"]
+  }
+}
+
+# Autoscaling
+
+resource "aws_appautoscaling_target" "dynamodb_table_read_target" {
+  count              = "${var.enable ? (var.enable_dynamodb_autoscaling ? 1 : 0) : 0}"
+  max_capacity       = "${var.dynamodb_max_read_capacity}"
+  min_capacity       = "${var.dynamodb_min_read_capacity}"
+  resource_id        = "table/${aws_dynamodb_table.vault_dynamodb_table.name}"
+  scalable_dimension = "dynamodb:table:ReadCapacityUnits"
+  service_namespace  = "dynamodb"
+}
+
+resource "aws_appautoscaling_target" "dynamodb_table_write_target" {
+  count              = "${var.enable ? (var.enable_dynamodb_autoscaling ? 1 : 0) : 0}"
+  max_capacity       = "${var.dynamodb_max_write_capacity}"
+  min_capacity       = "${var.dynamodb_min_write_capacity}"
+  resource_id        = "table/${aws_dynamodb_table.vault_dynamodb_table.name}"
+  scalable_dimension = "dynamodb:table:WriteCapacityUnits"
+  service_namespace  = "dynamodb"
+}
+
+resource "aws_appautoscaling_policy" "dynamodb_table_read_policy" {
+  count              = "${var.enable ? (var.enable_dynamodb_autoscaling ? 1 : 0) : 0}"
+  name               = "DynamoDBReadCapacityUtilization:${aws_appautoscaling_target.dynamodb_table_read_target.resource_id}"
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = "${aws_appautoscaling_target.dynamodb_table_read_target.resource_id}"
+  scalable_dimension = "${aws_appautoscaling_target.dynamodb_table_read_target.scalable_dimension}"
+  service_namespace  = "${aws_appautoscaling_target.dynamodb_table_read_target.service_namespace}"
+
+  target_tracking_scaling_policy_configuration {
+    predefined_metric_specification {
+      predefined_metric_type = "DynamoDBReadCapacityUtilization"
+    }
+
+    target_value = 70
+  }
+}
+
+resource "aws_appautoscaling_policy" "dynamodb_table_write_policy" {
+  count              = "${var.enable ? (var.enable_dynamodb_autoscaling ? 1 : 0) : 0}"
+  name               = "DynamoDBWriteCapacityUtilization:${aws_appautoscaling_target.dynamodb_table_write_target.resource_id}"
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = "${aws_appautoscaling_target.dynamodb_table_write_target.resource_id}"
+  scalable_dimension = "${aws_appautoscaling_target.dynamodb_table_write_target.scalable_dimension}"
+  service_namespace  = "${aws_appautoscaling_target.dynamodb_table_write_target.service_namespace}"
+
+  target_tracking_scaling_policy_configuration {
+    predefined_metric_specification {
+      predefined_metric_type = "DynamoDBWriteCapacityUtilization"
+    }
+
+    target_value = 70
+  }
+}

--- a/dynamodb-table/outputs.tf
+++ b/dynamodb-table/outputs.tf
@@ -1,0 +1,11 @@
+output "table_name" {
+  value = "${join("", aws_dynamodb_table.vault_dynamodb_table.*.name)}"
+}
+
+output "write_autoscaling_policy_arn" {
+  value = "${join("", aws_appautoscaling_policy.dynamodb_table_read_policy.*.arn)}"
+}
+
+output "read_autoscaling_policy_arn" {
+  value = "${join("", aws_appautoscaling_policy.dynamodb_table_write_policy.*.arn)}"
+}

--- a/dynamodb-table/variables.tf
+++ b/dynamodb-table/variables.tf
@@ -1,0 +1,10 @@
+variable "dynamodb_table_name_override" {}
+variable "environment" {}
+variable "project" {}
+variable "enable_point_in_time_recovery" {}
+variable "dynamodb_max_read_capacity" {}
+variable "dynamodb_min_read_capacity" {}
+variable "dynamodb_max_write_capacity" {}
+variable "dynamodb_min_write_capacity" {}
+variable "enable_dynamodb_autoscaling" {}
+variable "enable" {}

--- a/examples/global-table/basic_network.tf
+++ b/examples/global-table/basic_network.tf
@@ -1,0 +1,13 @@
+module "vpc" {
+  source                            = "github.com/skyscrapers/terraform-network//vpc?ref=3.4.1"
+  cidr_block                        = "${var.cidr_block}"
+  environment                       = "test"
+  project                           = "${var.project}"
+  amount_private_management_subnets = 2
+}
+
+module "nat_gateway" {
+  source               = "github.com/skyscrapers/terraform-network//nat_gateway?ref=3.4.1"
+  private_route_tables = "${module.vpc.private_rts}"
+  public_subnets       = "${module.vpc.public_nat-bastion}"
+}

--- a/examples/global-table/main.tf
+++ b/examples/global-table/main.tf
@@ -1,0 +1,51 @@
+provider "aws" {}
+
+provider "aws" {
+  alias  = "replica"
+  region = "${var.dynamodb_replica_region}"
+}
+
+# Get the latest ubuntu ami
+data "aws_ami" "ubuntu" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["099720109477"] # Canonical
+}
+
+data "aws_region" "main" {}
+
+module "ha_vault" {
+  source                = "../../vault"
+  ami                   = "${length(var.custom_ami) == 0 ? data.aws_ami.ubuntu.id : var.custom_ami}"
+  project               = "${var.project}"
+  vault1_subnet         = "${module.vpc.private_app_subnets[0]}"
+  vault2_subnet         = "${module.vpc.private_app_subnets[1]}"
+  vpc_id                = "${module.vpc.vpc_id}"
+  lb_subnets            = "${module.vpc.public_lb_subnets}"
+  acm_arn               = "${var.vault_acm_arn}"
+  dns_root              = "${var.vault_dns_root}"
+  instance_type         = "${var.instance_type}"
+  vault_nproc           = "1"
+  key_name              = "${var.key_name}"
+  lb_internal           = "${var.lb_internal}"
+  download_url_vault    = "https://releases.hashicorp.com/vault/${var.vault_version}/vault_${var.vault_version}_linux_amd64.zip"
+  environment           = "test"
+  le_staging            = "${var.le_staging}"
+  le_email              = "${var.le_email}"
+  enable_dynamodb_replica_table = true
+
+  providers = {
+    aws = "aws"
+    aws.replica = "aws.replica"
+  }
+}

--- a/examples/global-table/variables.tf
+++ b/examples/global-table/variables.tf
@@ -1,0 +1,40 @@
+variable "vault_acm_arn" {
+}
+
+variable "vault_dns_root" {
+}
+
+variable "instance_type" {
+  default = "t2.small"
+}
+
+variable "lb_internal" {
+  default = "true"
+}
+
+variable "vault_version" {
+  default = "0.10.3"
+}
+
+variable "cidr_block" {
+  default = "172.30.0.0/16"
+}
+
+variable "custom_ami" {
+  default = ""
+}
+
+variable "project" {
+}
+
+variable "le_staging" {
+  default = false
+}
+
+variable "key_name" {
+  default = ""
+}
+
+variable "dynamodb_replica_region" {}
+
+variable "le_email" {}

--- a/test/README.md
+++ b/test/README.md
@@ -52,6 +52,7 @@ dep ensure
 cd test
 export TEST_R53_ZONE_NAME="test.example.com"
 export TEST_ACM_ARN="arn:aws:acm:eu-west-1:1234567890:certificate/uev7722-434t-55g7-86ba-a882d9da1fa5"
+export TEST_LE_EMAIL="something@example.com"
 go test -v -timeout 60m
 ```
 
@@ -63,5 +64,6 @@ To run a specific test called `TestFoo`:
 cd test
 export TEST_R53_ZONE_NAME="test.example.com"
 export TEST_ACM_ARN="arn:aws:acm:eu-west-1:1234567890:certificate/uev7722-434t-55g7-86ba-a882d9da1fa5"
+export TEST_LE_EMAIL="something@example.com"
 go test -v -timeout 60m -run TestFoo
 ```

--- a/test/basic_example_test.go
+++ b/test/basic_example_test.go
@@ -56,10 +56,59 @@ func TestBasicExample(t *testing.T) {
 				"vault_acm_arn": os.Getenv("TEST_ACM_ARN"),
 				"vault_dns_root": os.Getenv("TEST_R53_ZONE_NAME"),
 				"le_email": os.Getenv("TEST_LE_EMAIL"),
+				"key_name": os.Getenv("TEST_KEY_NAME"),
 				"vault_version": "0.9.3",
 				"project": projectName,
 				"le_staging": true,
 				"lb_internal": false,
+			},
+
+			EnvVars: map[string]string{
+				"AWS_DEFAULT_REGION": "eu-west-1",
+			},
+		}
+
+		test_structure.SaveTerraformOptions(t, exampleFolder, terraformOptions)
+
+		// This will run `terraform init` and `terraform apply` and fail the test if there are any errors
+		terraform.InitAndApply(t, terraformOptions)
+	})
+
+	test_structure.RunTestStage(t, "validate", func() {
+		initializeAndUnsealVaultCluster(t)
+	})
+}
+
+func TestGlobalTableExample(t *testing.T) {
+	t.Parallel()
+
+	// The path to where our Terraform code is located
+	exampleFolder := "../examples/global-table"
+
+	defer test_structure.RunTestStage(t, "teardown", func() {
+		terraformOptions := test_structure.LoadTerraformOptions(t, exampleFolder)
+		// At the end of the test, run `terraform destroy` to clean up any resources that were created
+		terraform.Destroy(t, terraformOptions)
+	})
+
+	test_structure.RunTestStage(t, "deploy", func() {
+		uniqueId := random.UniqueId()
+		projectName := fmt.Sprintf("vault-%s", uniqueId)
+
+		terraformOptions := &terraform.Options{
+			TerraformDir: exampleFolder,
+
+			// Variables to pass to our Terraform code using -var options
+			Vars: map[string]interface{}{
+				"vault_acm_arn": os.Getenv("TEST_ACM_ARN"),
+				"vault_dns_root": os.Getenv("TEST_R53_ZONE_NAME"),
+				"le_email": os.Getenv("TEST_LE_EMAIL"),
+				"key_name": os.Getenv("TEST_KEY_NAME"),
+				"vault_version": "0.9.3",
+				"project": projectName,
+				"le_staging": true,
+				"lb_internal": false,
+				"dynamodb_replica_region": "eu-west-2",
 			},
 
 			EnvVars: map[string]string{

--- a/test/basic_example_test.go
+++ b/test/basic_example_test.go
@@ -33,8 +33,6 @@ type VaultCluster struct {
 
 // An example of how to test the simple Terraform module in examples/basic using Terratest.
 func TestBasicExample(t *testing.T) {
-	t.Parallel()
-
 	// The path to where our Terraform code is located
 	exampleFolder := "../examples/basic"
 
@@ -80,8 +78,6 @@ func TestBasicExample(t *testing.T) {
 }
 
 func TestGlobalTableExample(t *testing.T) {
-	t.Parallel()
-
 	// The path to where our Terraform code is located
 	exampleFolder := "../examples/global-table"
 

--- a/vault/cloud-config.tf
+++ b/vault/cloud-config.tf
@@ -1,3 +1,7 @@
+locals {
+  dynamodb_table_name = "${var.enable_dynamodb_replica_table ? join("", aws_dynamodb_global_table.vault_global_table.*.id) : module.main_dynamodb_table.table_name}"
+}
+
 data "template_cloudinit_config" "vault1" {
   gzip          = true
   base64_encode = true
@@ -47,7 +51,7 @@ data "template_file" "cloudconfig_vault1" {
     vault_cluster_dns   = "vault.${var.dns_root}"
     teleport_config     = "${var.teleport_auth_server == "" ? "" : module.teleport_vault1.teleport_config_cloudinit}"
     teleport_service    = "${var.teleport_auth_server == "" ? "" : module.teleport_vault1.teleport_service_cloudinit}"
-    dynamodb_table_name = "${aws_dynamodb_table.vault_dynamodb_table.name}"
+    dynamodb_table_name = "${local.dynamodb_table_name}"
     le_staging          = "${var.le_staging ? "--staging" : ""}"
     le_email            = "${var.le_email}"
   }
@@ -62,7 +66,7 @@ data "template_file" "cloudconfig_vault2" {
     vault_cluster_dns   = "vault.${var.dns_root}"
     teleport_config     = "${var.teleport_auth_server == "" ? "" : module.teleport_vault2.teleport_config_cloudinit}"
     teleport_service    = "${var.teleport_auth_server == "" ? "" : module.teleport_vault2.teleport_service_cloudinit}"
-    dynamodb_table_name = "${aws_dynamodb_table.vault_dynamodb_table.name}"
+    dynamodb_table_name = "${local.dynamodb_table_name}"
     le_staging          = "${var.le_staging ? "--staging" : ""}"
     le_email            = "${var.le_email}"
   }

--- a/vault/iam.tf
+++ b/vault/iam.tf
@@ -1,9 +1,3 @@
-data "aws_caller_identity" "current" {}
-
-data "aws_region" "current" {
-  current = true
-}
-
 data "aws_iam_policy_document" "vault" {
   statement {
     sid = "getR53"
@@ -44,7 +38,7 @@ data "aws_iam_policy_document" "vault" {
     ]
 
     resources = [
-      "arn:aws:dynamodb:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:table/${aws_dynamodb_table.vault_dynamodb_table.name}",
+      "arn:aws:dynamodb:${data.aws_region.main.name}:${data.aws_caller_identity.current.account_id}:table/${local.dynamodb_table_name}",
     ]
   }
 
@@ -62,7 +56,7 @@ data "aws_iam_policy_document" "vault" {
     ]
 
     resources = [
-      "arn:aws:dynamodb:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:table/*",
+      "arn:aws:dynamodb:${data.aws_region.main.name}:${data.aws_caller_identity.current.account_id}:table/*",
     ]
   }
 

--- a/vault/main.tf
+++ b/vault/main.tf
@@ -1,0 +1,13 @@
+provider "aws" {}
+
+provider "aws" {
+  alias = "replica"
+}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_region" "main" {}
+
+data "aws_region" "replica" {
+  provider = "aws.replica"
+}

--- a/vault/outputs.tf
+++ b/vault/outputs.tf
@@ -85,5 +85,5 @@ output "alb_arn" {
 
 output "dynamodb_table_name" {
   description = "The Vault dynamodb table name"
-  value       = "${aws_dynamodb_table.vault_dynamodb_table.name}"
+  value       = "${local.dynamodb_table_name}"
 }

--- a/vault/outputs.tf
+++ b/vault/outputs.tf
@@ -87,3 +87,13 @@ output "dynamodb_table_name" {
   description = "The Vault dynamodb table name"
   value       = "${local.dynamodb_table_name}"
 }
+
+output "main_dynamodb_table_region" {
+  description = "Region where the main DynamoDB table will be created"
+  value       = "${data.aws_region.main.name}"
+}
+
+output "replica_dynamodb_table_region" {
+  description = "Region where the replica DynamoDB table will be created, if enabled"
+  value       = "${data.aws_region.replica.name}"
+}

--- a/vault/variables.tf
+++ b/vault/variables.tf
@@ -140,5 +140,6 @@ variable "enable_point_in_time_recovery" {
 }
 
 variable "enable_dynamodb_replica_table" {
-  default = false
+  description = "Setting this to true will create a DynamoDB table on another region and enable global tables for replication. The replica table is going to be managed by the 'replica' Terraform provider"
+  default     = false
 }

--- a/vault/variables.tf
+++ b/vault/variables.tf
@@ -100,6 +100,16 @@ variable "dynamodb_min_read_capacity" {
   default     = "5"
 }
 
+variable "replica_dynamodb_max_read_capacity" {
+  description = "The max read capacity of the Vault dynamodb replica table"
+  default     = "5"
+}
+
+variable "replica_dynamodb_min_read_capacity" {
+  description = "The min read capacity of the Vault dynamodb replica table"
+  default     = "5"
+}
+
 variable "dynamodb_max_write_capacity" {
   description = "The max write capacity of the Vault dynamodb table"
   default     = "100"
@@ -127,4 +137,8 @@ variable "le_email" {
 variable "enable_point_in_time_recovery" {
   description = "Whether to enable point-in-time recovery - note that it can take up to 10 minutes to enable for new tables. Note that additional charges will apply by enabling this setting (https://aws.amazon.com/dynamodb/pricing/)"
   default     = true
+}
+
+variable "enable_dynamodb_replica_table" {
+  default = false
 }


### PR DESCRIPTION
This new option can be toggled on and off and is off by default.
When it's on, it'll create a new DynamoDB table on another region and enable the global tables functionality between the two tables.

As per https://github.com/skyscrapers/engineering/issues/56

It's a breaking change so I'll do a major version bump of the module.