### PR TITLE
fix region selection for the dynamodb table in vault config

### DIFF
--- a/vault/cloud-config.tf
+++ b/vault/cloud-config.tf
@@ -54,6 +54,7 @@ data "template_file" "cloudconfig_vault1" {
     dynamodb_table_name = "${local.dynamodb_table_name}"
     acme_server         = "${var.acme_server}"
     le_email            = "${var.le_email}"
+    region              = "${data.aws_region.main.name}"
   }
 }
 
@@ -69,6 +70,7 @@ data "template_file" "cloudconfig_vault2" {
     dynamodb_table_name = "${local.dynamodb_table_name}"
     acme_server         = "${var.acme_server}"
     le_email            = "${var.le_email}"
+    region              = "${data.aws_region.main.name}"
   }
 }
 

--- a/vault/templates/configure.yaml.tpl
+++ b/vault/templates/configure.yaml.tpl
@@ -58,7 +58,7 @@ ${teleport_service}
 - content: |
     storage "dynamodb" {
       ha_enabled = "true"
-      region     = "eu-west-1"
+      region     = "${region}"
       table      = "${dynamodb_table_name}"
     }
 


### PR DESCRIPTION
This PR changes the hardcoded region value to a dynamic value based on the correct region where the dynamodb table for vault is located.