### PR TITLE
Migrate terraform code to 0.12 syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,13 +68,8 @@ module "vault" {
 | acme\_server | ACME server where to point `certbot` on the Teleport server to fetch an SSL certificate. Useful if you want to point to the letsencrypt staging server. | string | `"https://acme-v01.api.letsencrypt.org/directory"` | no |
 | ami | The AMI ID to use for the vault instances | string | n/a | yes |
 | dns\_root | The root domain to configure for vault | string | `"production.skyscrape.rs"` | no |
-| dynamodb\_max\_read\_capacity | The max read capacity of the Vault dynamodb table | string | `"100"` | no |
-| dynamodb\_max\_write\_capacity | The max write capacity of the Vault dynamodb table | string | `"100"` | no |
-| dynamodb\_min\_read\_capacity | The min read capacity of the Vault dynamodb table | string | `"5"` | no |
-| dynamodb\_min\_write\_capacity | The min write capacity of the Vault dynamodb table | string | `"5"` | no |
 | dynamodb\_table\_name\_override | Override Vault's DynamoDB table name with this variable. This module will generate a name if this is left empty (default behavior) | string | `""` | no |
 | ec2\_instances\_cpu\_credits | The type of cpu credits to use | string | `"standard"` | no |
-| enable\_dynamodb\_autoscaling | Enables the autoscaling feature on the Vault dynamodb table | string | `"true"` | no |
 | enable\_dynamodb\_replica\_table | Setting this to true will create a DynamoDB table on another region and enable global tables for replication. The replica table is going to be managed by the 'replica' Terraform provider | string | `"false"` | no |
 | enable\_point\_in\_time\_recovery | Whether to enable point-in-time recovery - note that it can take up to 10 minutes to enable for new tables. Note that [additional charges](https://aws.amazon.com/dynamodb/pricing/) will apply by enabling this setting | string | `"true"` | no |
 | enable\_ui | Enables the [Vault UI](https://www.vaultproject.io/docs/configuration/ui/index.html) | string | `"true"` | no |
@@ -85,8 +80,6 @@ module "vault" {
 | lb\_subnets | The subnets to use for the alb | list | n/a | yes |
 | le\_email | The email address that's going to be used to register to LetsEncrypt | string | n/a | yes |
 | project | Name of the project | string | n/a | yes |
-| replica\_dynamodb\_max\_read\_capacity | The max read capacity of the Vault dynamodb replica table | string | `"5"` | no |
-| replica\_dynamodb\_min\_read\_capacity | The min read capacity of the Vault dynamodb replica table | string | `"5"` | no |
 | teleport\_auth\_server | The hostname or ip of the Teleport auth server. If empty, Teleport integration will be disabled (default). | string | `""` | no |
 | teleport\_node\_sg | The security-group ID of the teleport server | string | `""` | no |
 | teleport\_token\_1 | The Teleport token for the first instance. This can be a dynamic short-lived token | string | `""` | no |

--- a/ci/run_tests.yaml
+++ b/ci/run_tests.yaml
@@ -33,7 +33,9 @@ run:
       chmod +x /usr/local/bin/terraform
 
       # Set the Vault version env variable
-      export TEST_VAULT_VERSION="`cat vault-release/version`"
+      # Sometimes vault versions can look like "1.2.3+ent". Until we find
+      # a better solution to deal with this versions, we'll clean it up with `cut`
+      export TEST_VAULT_VERSION="`cat vault-release/version | cut -d+ -f1`"
 
       export GOPATH=$PWD/gopath
 

--- a/ci/run_tests.yaml
+++ b/ci/run_tests.yaml
@@ -26,7 +26,7 @@ run:
   args:
     - -exc
     - |
-      apk add --update unzip curl dep git
+      apk add --update unzip curl dep git build-base
 
       # Unzip terraform binary
       unzip terraform-release/terraform_*_linux_amd64.zip -d /usr/local/bin

--- a/ci/run_tests.yaml
+++ b/ci/run_tests.yaml
@@ -4,22 +4,22 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: '1.9-alpine'
+    tag: "1.12-alpine"
 
 params:
-  AWS_DEFAULT_REGION: 'eu-west-1'
+  AWS_DEFAULT_REGION: "eu-west-1"
   AWS_ACCESS_KEY_ID:
   AWS_SECRET_ACCESS_KEY:
   AWS_SESSION_TOKEN:
-  TEST_R53_ZONE_NAME: ''
-  TEST_ACM_ARN: ''
-  TEST_LE_EMAIL: 'something@example.com'
+  TEST_R53_ZONE_NAME: ""
+  TEST_ACM_ARN: ""
+  TEST_LE_EMAIL: "something@example.com"
 
 inputs:
-- name: terraform-src
-  path: gopath/src/github.com/skyscrapers/terraform-vault
-- name: vault-release
-- name: terraform-release
+  - name: terraform-src
+    path: gopath/src/github.com/skyscrapers/terraform-vault
+  - name: vault-release
+  - name: terraform-release
 
 run:
   path: sh

--- a/dynamodb-table/main.tf
+++ b/dynamodb-table/main.tf
@@ -5,8 +5,7 @@ locals {
 resource "aws_dynamodb_table" "vault_dynamodb_table" {
   count            = var.enable ? 1 : 0
   name             = local.dynamodb_table_name
-  read_capacity    = 5
-  write_capacity   = 5
+  billing_mode     = "PAY_PER_REQUEST"
   hash_key         = "Path"
   range_key        = "Key"
   stream_enabled   = true
@@ -30,63 +29,5 @@ resource "aws_dynamodb_table" "vault_dynamodb_table" {
 
   point_in_time_recovery {
     enabled = var.enable_point_in_time_recovery
-  }
-
-  lifecycle {
-    ignore_changes = [read_capacity, write_capacity]
-  }
-}
-
-# Autoscaling
-
-resource "aws_appautoscaling_target" "dynamodb_table_read_target" {
-  count              = var.enable && var.enable_dynamodb_autoscaling ? 1 : 0
-  max_capacity       = var.dynamodb_max_read_capacity
-  min_capacity       = var.dynamodb_min_read_capacity
-  resource_id        = "table/${aws_dynamodb_table.vault_dynamodb_table[0].name}"
-  scalable_dimension = "dynamodb:table:ReadCapacityUnits"
-  service_namespace  = "dynamodb"
-}
-
-resource "aws_appautoscaling_target" "dynamodb_table_write_target" {
-  count              = var.enable && var.enable_dynamodb_autoscaling ? 1 : 0
-  max_capacity       = var.dynamodb_max_write_capacity
-  min_capacity       = var.dynamodb_min_write_capacity
-  resource_id        = "table/${aws_dynamodb_table.vault_dynamodb_table[0].name}"
-  scalable_dimension = "dynamodb:table:WriteCapacityUnits"
-  service_namespace  = "dynamodb"
-}
-
-resource "aws_appautoscaling_policy" "dynamodb_table_read_policy" {
-  count              = var.enable && var.enable_dynamodb_autoscaling ? 1 : 0
-  name               = "DynamoDBReadCapacityUtilization:${aws_appautoscaling_target.dynamodb_table_read_target[0].resource_id}"
-  policy_type        = "TargetTrackingScaling"
-  resource_id        = aws_appautoscaling_target.dynamodb_table_read_target[0].resource_id
-  scalable_dimension = aws_appautoscaling_target.dynamodb_table_read_target[0].scalable_dimension
-  service_namespace  = aws_appautoscaling_target.dynamodb_table_read_target[0].service_namespace
-
-  target_tracking_scaling_policy_configuration {
-    predefined_metric_specification {
-      predefined_metric_type = "DynamoDBReadCapacityUtilization"
-    }
-
-    target_value = 70
-  }
-}
-
-resource "aws_appautoscaling_policy" "dynamodb_table_write_policy" {
-  count              = var.enable && var.enable_dynamodb_autoscaling ? 1 : 0
-  name               = "DynamoDBWriteCapacityUtilization:${aws_appautoscaling_target.dynamodb_table_write_target[0].resource_id}"
-  policy_type        = "TargetTrackingScaling"
-  resource_id        = aws_appautoscaling_target.dynamodb_table_write_target[0].resource_id
-  scalable_dimension = aws_appautoscaling_target.dynamodb_table_write_target[0].scalable_dimension
-  service_namespace  = aws_appautoscaling_target.dynamodb_table_write_target[0].service_namespace
-
-  target_tracking_scaling_policy_configuration {
-    predefined_metric_specification {
-      predefined_metric_type = "DynamoDBWriteCapacityUtilization"
-    }
-
-    target_value = 70
   }
 }

--- a/dynamodb-table/main.tf
+++ b/dynamodb-table/main.tf
@@ -1,10 +1,10 @@
 locals {
-  dynamodb_table_name = "${var.dynamodb_table_name_override == "" ? format("vault-%s-%s", var.environment, var.project) : var.dynamodb_table_name_override}"
+  dynamodb_table_name = coalesce(var.dynamodb_table_name_override, format("vault-%s-%s", var.environment, var.project))
 }
 
 resource "aws_dynamodb_table" "vault_dynamodb_table" {
-  count            = "${var.enable ? 1 : 0}"
-  name             = "${local.dynamodb_table_name}"
+  count            = var.enable ? 1 : 0
+  name             = local.dynamodb_table_name
   read_capacity    = 5
   write_capacity   = 5
   hash_key         = "Path"
@@ -22,48 +22,48 @@ resource "aws_dynamodb_table" "vault_dynamodb_table" {
     type = "S"
   }
 
-  tags {
-    Name        = "${local.dynamodb_table_name}"
-    Environment = "${var.environment}"
-    Project     = "${var.project}"
+  tags = {
+    Name        = local.dynamodb_table_name
+    Environment = var.environment
+    Project     = var.project
   }
 
   point_in_time_recovery {
-    enabled = "${var.enable_point_in_time_recovery}"
+    enabled = var.enable_point_in_time_recovery
   }
 
   lifecycle {
-    ignore_changes = ["read_capacity", "write_capacity"]
+    ignore_changes = [read_capacity, write_capacity]
   }
 }
 
 # Autoscaling
 
 resource "aws_appautoscaling_target" "dynamodb_table_read_target" {
-  count              = "${var.enable ? (var.enable_dynamodb_autoscaling ? 1 : 0) : 0}"
-  max_capacity       = "${var.dynamodb_max_read_capacity}"
-  min_capacity       = "${var.dynamodb_min_read_capacity}"
-  resource_id        = "table/${aws_dynamodb_table.vault_dynamodb_table.name}"
+  count              = var.enable && var.enable_dynamodb_autoscaling ? 1 : 0
+  max_capacity       = var.dynamodb_max_read_capacity
+  min_capacity       = var.dynamodb_min_read_capacity
+  resource_id        = "table/${aws_dynamodb_table.vault_dynamodb_table[0].name}"
   scalable_dimension = "dynamodb:table:ReadCapacityUnits"
   service_namespace  = "dynamodb"
 }
 
 resource "aws_appautoscaling_target" "dynamodb_table_write_target" {
-  count              = "${var.enable ? (var.enable_dynamodb_autoscaling ? 1 : 0) : 0}"
-  max_capacity       = "${var.dynamodb_max_write_capacity}"
-  min_capacity       = "${var.dynamodb_min_write_capacity}"
-  resource_id        = "table/${aws_dynamodb_table.vault_dynamodb_table.name}"
+  count              = var.enable && var.enable_dynamodb_autoscaling ? 1 : 0
+  max_capacity       = var.dynamodb_max_write_capacity
+  min_capacity       = var.dynamodb_min_write_capacity
+  resource_id        = "table/${aws_dynamodb_table.vault_dynamodb_table[0].name}"
   scalable_dimension = "dynamodb:table:WriteCapacityUnits"
   service_namespace  = "dynamodb"
 }
 
 resource "aws_appautoscaling_policy" "dynamodb_table_read_policy" {
-  count              = "${var.enable ? (var.enable_dynamodb_autoscaling ? 1 : 0) : 0}"
-  name               = "DynamoDBReadCapacityUtilization:${aws_appautoscaling_target.dynamodb_table_read_target.resource_id}"
+  count              = var.enable && var.enable_dynamodb_autoscaling ? 1 : 0
+  name               = "DynamoDBReadCapacityUtilization:${aws_appautoscaling_target.dynamodb_table_read_target[0].resource_id}"
   policy_type        = "TargetTrackingScaling"
-  resource_id        = "${aws_appautoscaling_target.dynamodb_table_read_target.resource_id}"
-  scalable_dimension = "${aws_appautoscaling_target.dynamodb_table_read_target.scalable_dimension}"
-  service_namespace  = "${aws_appautoscaling_target.dynamodb_table_read_target.service_namespace}"
+  resource_id        = aws_appautoscaling_target.dynamodb_table_read_target[0].resource_id
+  scalable_dimension = aws_appautoscaling_target.dynamodb_table_read_target[0].scalable_dimension
+  service_namespace  = aws_appautoscaling_target.dynamodb_table_read_target[0].service_namespace
 
   target_tracking_scaling_policy_configuration {
     predefined_metric_specification {
@@ -75,12 +75,12 @@ resource "aws_appautoscaling_policy" "dynamodb_table_read_policy" {
 }
 
 resource "aws_appautoscaling_policy" "dynamodb_table_write_policy" {
-  count              = "${var.enable ? (var.enable_dynamodb_autoscaling ? 1 : 0) : 0}"
-  name               = "DynamoDBWriteCapacityUtilization:${aws_appautoscaling_target.dynamodb_table_write_target.resource_id}"
+  count              = var.enable && var.enable_dynamodb_autoscaling ? 1 : 0
+  name               = "DynamoDBWriteCapacityUtilization:${aws_appautoscaling_target.dynamodb_table_write_target[0].resource_id}"
   policy_type        = "TargetTrackingScaling"
-  resource_id        = "${aws_appautoscaling_target.dynamodb_table_write_target.resource_id}"
-  scalable_dimension = "${aws_appautoscaling_target.dynamodb_table_write_target.scalable_dimension}"
-  service_namespace  = "${aws_appautoscaling_target.dynamodb_table_write_target.service_namespace}"
+  resource_id        = aws_appautoscaling_target.dynamodb_table_write_target[0].resource_id
+  scalable_dimension = aws_appautoscaling_target.dynamodb_table_write_target[0].scalable_dimension
+  service_namespace  = aws_appautoscaling_target.dynamodb_table_write_target[0].service_namespace
 
   target_tracking_scaling_policy_configuration {
     predefined_metric_specification {

--- a/dynamodb-table/main.tf
+++ b/dynamodb-table/main.tf
@@ -10,6 +10,7 @@ resource "aws_dynamodb_table" "vault_dynamodb_table" {
   range_key        = "Key"
   stream_enabled   = true
   stream_view_type = "NEW_AND_OLD_IMAGES"
+  tags             = var.tags
 
   attribute {
     name = "Key"
@@ -19,12 +20,6 @@ resource "aws_dynamodb_table" "vault_dynamodb_table" {
   attribute {
     name = "Path"
     type = "S"
-  }
-
-  tags = {
-    Name        = local.dynamodb_table_name
-    Environment = var.environment
-    Project     = var.project
   }
 
   point_in_time_recovery {

--- a/dynamodb-table/outputs.tf
+++ b/dynamodb-table/outputs.tf
@@ -1,11 +1,3 @@
 output "table_name" {
   value = join("", aws_dynamodb_table.vault_dynamodb_table.*.name)
 }
-
-output "write_autoscaling_policy_arn" {
-  value = join("", aws_appautoscaling_policy.dynamodb_table_read_policy.*.arn)
-}
-
-output "read_autoscaling_policy_arn" {
-  value = join("", aws_appautoscaling_policy.dynamodb_table_write_policy.*.arn)
-}

--- a/dynamodb-table/outputs.tf
+++ b/dynamodb-table/outputs.tf
@@ -1,11 +1,11 @@
 output "table_name" {
-  value = "${join("", aws_dynamodb_table.vault_dynamodb_table.*.name)}"
+  value = join("", aws_dynamodb_table.vault_dynamodb_table.*.name)
 }
 
 output "write_autoscaling_policy_arn" {
-  value = "${join("", aws_appautoscaling_policy.dynamodb_table_read_policy.*.arn)}"
+  value = join("", aws_appautoscaling_policy.dynamodb_table_read_policy.*.arn)
 }
 
 output "read_autoscaling_policy_arn" {
-  value = "${join("", aws_appautoscaling_policy.dynamodb_table_write_policy.*.arn)}"
+  value = join("", aws_appautoscaling_policy.dynamodb_table_write_policy.*.arn)
 }

--- a/dynamodb-table/variables.tf
+++ b/dynamodb-table/variables.tf
@@ -1,10 +1,40 @@
-variable "dynamodb_table_name_override" {}
-variable "environment" {}
-variable "project" {}
-variable "enable_point_in_time_recovery" {}
-variable "dynamodb_max_read_capacity" {}
-variable "dynamodb_min_read_capacity" {}
-variable "dynamodb_max_write_capacity" {}
-variable "dynamodb_min_write_capacity" {}
-variable "enable_dynamodb_autoscaling" {}
-variable "enable" {}
+variable "dynamodb_table_name_override" {
+  default = null
+  type    = string
+}
+
+variable "environment" {
+  type = string
+}
+
+variable "project" {
+  type = string
+}
+
+variable "enable_point_in_time_recovery" {
+  type = bool
+}
+
+variable "dynamodb_max_read_capacity" {
+  type = number
+}
+
+variable "dynamodb_min_read_capacity" {
+  type = number
+}
+
+variable "dynamodb_max_write_capacity" {
+  type = number
+}
+
+variable "dynamodb_min_write_capacity" {
+  type = number
+}
+
+variable "enable_dynamodb_autoscaling" {
+  type = bool
+}
+
+variable "enable" {
+  type = bool
+}

--- a/dynamodb-table/variables.tf
+++ b/dynamodb-table/variables.tf
@@ -15,26 +15,6 @@ variable "enable_point_in_time_recovery" {
   type = bool
 }
 
-variable "dynamodb_max_read_capacity" {
-  type = number
-}
-
-variable "dynamodb_min_read_capacity" {
-  type = number
-}
-
-variable "dynamodb_max_write_capacity" {
-  type = number
-}
-
-variable "dynamodb_min_write_capacity" {
-  type = number
-}
-
-variable "enable_dynamodb_autoscaling" {
-  type = bool
-}
-
 variable "enable" {
   type = bool
 }

--- a/dynamodb-table/variables.tf
+++ b/dynamodb-table/variables.tf
@@ -18,3 +18,8 @@ variable "enable_point_in_time_recovery" {
 variable "enable" {
   type = bool
 }
+
+variable "tags" {
+  default = null
+  type    = map(string)
+}

--- a/dynamodb-table/versions.tf
+++ b/dynamodb-table/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}

--- a/examples/basic/basic_network.tf
+++ b/examples/basic/basic_network.tf
@@ -1,13 +1,13 @@
 module "vpc" {
-  source                            = "github.com/skyscrapers/terraform-network//vpc?ref=3.4.1"
-  cidr_block                        = "${var.cidr_block}"
+  source                            = "github.com/skyscrapers/terraform-network//vpc?ref=4.0.0"
+  cidr_block                        = var.cidr_block
   environment                       = "test"
-  project                           = "${var.project}"
+  project                           = var.project
   amount_private_management_subnets = 2
 }
 
 module "nat_gateway" {
-  source               = "github.com/skyscrapers/terraform-network//nat_gateway?ref=3.4.1"
-  private_route_tables = "${module.vpc.private_rts}"
-  public_subnets       = "${module.vpc.public_nat-bastion}"
+  source               = "github.com/skyscrapers/terraform-network//nat_gateway?ref=4.0.0"
+  private_route_tables = module.vpc.private_rts
+  public_subnets       = module.vpc.public_nat-bastion
 }

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -17,21 +17,21 @@ data "aws_ami" "ubuntu" {
 
 module "ha_vault" {
   source        = "../../vault"
-  ami           = "${length(var.custom_ami) == 0 ? data.aws_ami.ubuntu.id : var.custom_ami}"
-  project       = "${var.project}"
-  vault1_subnet = "${module.vpc.private_app_subnets[0]}"
-  vault2_subnet = "${module.vpc.private_app_subnets[1]}"
-  vpc_id        = "${module.vpc.vpc_id}"
-  lb_subnets    = "${module.vpc.public_lb_subnets}"
-  acm_arn       = "${var.vault_acm_arn}"
-  dns_root      = "${var.vault_dns_root}"
-  instance_type = "${var.instance_type}"
-  vault_nproc   = "1"
-  key_name      = "${var.key_name}"
-  lb_internal   = "${var.lb_internal}"
-  vault_version = "${var.vault_version}"
+  ami           = coalesce(var.custom_ami, data.aws_ami.ubuntu.id)
+  project       = var.project
+  vault1_subnet = module.vpc.private_app_subnets[0]
+  vault2_subnet = module.vpc.private_app_subnets[1]
+  vpc_id        = module.vpc.vpc_id
+  lb_subnets    = module.vpc.public_lb_subnets
+  acm_arn       = var.vault_acm_arn
+  dns_root      = var.vault_dns_root
+  instance_type = var.instance_type
+  vault_nproc   = 1
+  key_name      = var.key_name
+  lb_internal   = var.lb_internal
+  vault_version = var.vault_version
   environment   = "test"
-  acme_server   = "${var.acme_server}"
-  le_email      = "${var.le_email}"
+  acme_server   = var.acme_server
+  le_email      = var.le_email
   enable_ui     = false
 }

--- a/examples/basic/variables.tf
+++ b/examples/basic/variables.tf
@@ -9,17 +9,18 @@ variable "instance_type" {
 }
 
 variable "lb_internal" {
-  default = "true"
+  default = true
 }
 
-variable "vault_version" {}
+variable "vault_version" {
+}
 
 variable "cidr_block" {
   default = "172.30.0.0/16"
 }
 
 variable "custom_ami" {
-  default = ""
+  default = null
 }
 
 variable "project" {
@@ -30,7 +31,8 @@ variable "acme_server" {
 }
 
 variable "key_name" {
-  default = ""
+  default = null
 }
 
-variable "le_email" {}
+variable "le_email" {
+}

--- a/examples/basic/versions.tf
+++ b/examples/basic/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}

--- a/examples/global-table/basic_network.tf
+++ b/examples/global-table/basic_network.tf
@@ -1,13 +1,13 @@
 module "vpc" {
-  source                            = "github.com/skyscrapers/terraform-network//vpc?ref=3.4.1"
-  cidr_block                        = "${var.cidr_block}"
+  source                            = "github.com/skyscrapers/terraform-network//vpc?ref=4.0.0"
+  cidr_block                        = var.cidr_block
   environment                       = "test"
-  project                           = "${var.project}"
+  project                           = var.project
   amount_private_management_subnets = 2
 }
 
 module "nat_gateway" {
-  source               = "github.com/skyscrapers/terraform-network//nat_gateway?ref=3.4.1"
-  private_route_tables = "${module.vpc.private_rts}"
-  public_subnets       = "${module.vpc.public_nat-bastion}"
+  source               = "github.com/skyscrapers/terraform-network//nat_gateway?ref=4.0.0"
+  private_route_tables = module.vpc.private_rts
+  public_subnets       = module.vpc.public_nat-bastion
 }

--- a/examples/global-table/main.tf
+++ b/examples/global-table/main.tf
@@ -1,8 +1,9 @@
-provider "aws" {}
+provider "aws" {
+}
 
 provider "aws" {
   alias  = "replica"
-  region = "${var.dynamodb_replica_region}"
+  region = var.dynamodb_replica_region
 }
 
 # Get the latest ubuntu ami
@@ -22,31 +23,32 @@ data "aws_ami" "ubuntu" {
   owners = ["099720109477"] # Canonical
 }
 
-data "aws_region" "main" {}
+data "aws_region" "main" {
+}
 
 module "ha_vault" {
   source                        = "../../vault"
-  ami                           = "${length(var.custom_ami) == 0 ? data.aws_ami.ubuntu.id : var.custom_ami}"
-  project                       = "${var.project}"
-  vault1_subnet                 = "${module.vpc.private_app_subnets[0]}"
-  vault2_subnet                 = "${module.vpc.private_app_subnets[1]}"
-  vpc_id                        = "${module.vpc.vpc_id}"
-  lb_subnets                    = "${module.vpc.public_lb_subnets}"
-  acm_arn                       = "${var.vault_acm_arn}"
-  dns_root                      = "${var.vault_dns_root}"
-  instance_type                 = "${var.instance_type}"
-  vault_nproc                   = "1"
-  key_name                      = "${var.key_name}"
-  lb_internal                   = "${var.lb_internal}"
-  vault_version                 = "${var.vault_version}"
+  ami                           = coalesce(var.custom_ami, data.aws_ami.ubuntu.id)
+  project                       = var.project
+  vault1_subnet                 = module.vpc.private_app_subnets[0]
+  vault2_subnet                 = module.vpc.private_app_subnets[1]
+  vpc_id                        = module.vpc.vpc_id
+  lb_subnets                    = module.vpc.public_lb_subnets
+  acm_arn                       = var.vault_acm_arn
+  dns_root                      = var.vault_dns_root
+  instance_type                 = var.instance_type
+  vault_nproc                   = 1
+  key_name                      = var.key_name
+  lb_internal                   = var.lb_internal
+  vault_version                 = var.vault_version
   environment                   = "test"
-  acme_server                   = "${var.acme_server}"
-  le_email                      = "${var.le_email}"
+  acme_server                   = var.acme_server
+  le_email                      = var.le_email
   enable_dynamodb_replica_table = true
   enable_ui                     = true
 
   providers = {
-    aws         = "aws"
-    aws.replica = "aws.replica"
+    aws         = aws
+    aws.replica = aws.replica
   }
 }

--- a/examples/global-table/variables.tf
+++ b/examples/global-table/variables.tf
@@ -7,7 +7,7 @@ variable "instance_type" {
 }
 
 variable "lb_internal" {
-  default = "true"
+  default = true
 }
 
 variable "vault_version" {}
@@ -17,7 +17,7 @@ variable "cidr_block" {
 }
 
 variable "custom_ami" {
-  default = ""
+  default = null
 }
 
 variable "project" {}
@@ -27,7 +27,7 @@ variable "acme_server" {
 }
 
 variable "key_name" {
-  default = ""
+  default = null
 }
 
 variable "dynamodb_replica_region" {}

--- a/examples/global-table/versions.tf
+++ b/examples/global-table/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}

--- a/test/Gopkg.lock
+++ b/test/Gopkg.lock
@@ -10,7 +10,7 @@
   version = "v0.46.3"
 
 [[projects]]
-  digest = "1:9ffa8518e409db85e6eedec8542b844e5c20c7003c1e66523d748bfc5baae03c"
+  digest = "1:9f36fd450f701edb71fee1a1c217e3fc5b79e2fbc6793b191215988496fb25c1"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -22,7 +22,9 @@
     "aws/credentials",
     "aws/credentials/ec2rolecreds",
     "aws/credentials/endpointcreds",
+    "aws/credentials/processcreds",
     "aws/credentials/stscreds",
+    "aws/crr",
     "aws/csm",
     "aws/defaults",
     "aws/ec2metadata",
@@ -30,7 +32,10 @@
     "aws/request",
     "aws/session",
     "aws/signer/v4",
+    "internal/ini",
+    "internal/s3err",
     "internal/sdkio",
+    "internal/sdkmath",
     "internal/sdkrand",
     "internal/sdkuri",
     "internal/shareddefaults",
@@ -61,10 +66,11 @@
     "service/sqs",
     "service/ssm",
     "service/sts",
+    "service/sts/stsiface",
   ]
   pruneopts = "UT"
-  revision = "bc3f534c19ffdf835e524e11f0f825b3eaf541c3"
-  version = "v1.14.31"
+  revision = "63033a5636f9a9ad84cfaaf97b44e31286fb3c54"
+  version = "v1.25.2"
 
 [[projects]]
   digest = "1:7b94d37d65c0445053c6f3e73090e3966c1c29127035492c349e14f25c440359"
@@ -122,14 +128,6 @@
   revision = "d98b870cc4e05f1545532a80e9909be8216095b6"
 
 [[projects]]
-  digest = "1:fe8a03a8222d5b913f256972933d26d24ad7c8286692a42943bc01633cc8fce3"
-  name = "github.com/go-ini/ini"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "358ee7663966325963d4e8b2e1fbd570c5195153"
-  version = "v1.38.1"
-
-[[projects]]
   digest = "1:ec6f9bf5e274c833c911923c9193867f3f18788c461f76f05f62bb1510e0ae65"
   name = "github.com/go-sql-driver/mysql"
   packages = ["."]
@@ -171,12 +169,12 @@
   version = "v1.3.2"
 
 [[projects]]
-  branch = "master"
-  digest = "1:4a0c6bb4805508a6287675fac876be2ac1182539ca8a32468d8128882e9d5009"
+  digest = "1:e4f5819333ac698d294fe04dbf640f84719658d5c7ce195b10060cc37292ce79"
   name = "github.com/golang/snappy"
   packages = ["."]
   pruneopts = "UT"
-  revision = "2e65f85255dbc3072edf28d6b5b8efc472979f5a"
+  revision = "2a8bb927dd31d8daada140a5d09578521ce5c36a"
+  version = "v0.0.1"
 
 [[projects]]
   digest = "1:0bfbe13936953a98ae3cfe8ed6670d396ad81edf069a806d2f6515d7bb6950df"
@@ -257,56 +255,63 @@
   version = "v0.19.3"
 
 [[projects]]
-  branch = "master"
-  digest = "1:d1971637b21871ec2033a44ca87c99c5608a7340cb34ec75fab8d2ab503276c9"
+  digest = "1:0ade334594e69404d80d9d323445d2297ff8161637f9b2d347cc6973d2d6f05b"
   name = "github.com/hashicorp/errwrap"
   packages = ["."]
   pruneopts = "UT"
-  revision = "d6c0cd88035724dd42e0f335ae30161c20575ecc"
+  revision = "8a6fb523712970c966eefc6b39ed2c5e74880354"
+  version = "v1.0.0"
 
 [[projects]]
-  branch = "master"
-  digest = "1:77cb3be9b21ba7f1a4701e870c84ea8b66e7d74c7c8951c58155fdadae9414ec"
+  digest = "1:af105c7c5dc0b4ae41991f122cae860b9600f7d226072c2a83127048c991660c"
   name = "github.com/hashicorp/go-cleanhttp"
   packages = ["."]
   pruneopts = "UT"
-  revision = "d5fe4b57a186c716b0e00b8c301cbd9b4182694d"
+  revision = "eda1e5db218aad1db63ca4642c8906b26bcf2744"
+  version = "v0.5.1"
 
 [[projects]]
-  branch = "master"
-  digest = "1:46fb6a9f1b9667f32ac93e08b1da118b2c666991424ea12e848b05d4fe5155ef"
+  digest = "1:cf6b61e1b4c26b0c7526cee4a0cee6d8302b17798af4b2a56a90eedac0aef11a"
+  name = "github.com/hashicorp/go-hclog"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "5ccdce08c75b6c7b37af61159f13f6a4f5e2e928"
+  version = "v0.9.2"
+
+[[projects]]
+  digest = "1:f668349b83f7d779567c880550534addeca7ebadfdcf44b0b9c39be61864b4b7"
   name = "github.com/hashicorp/go-multierror"
   packages = ["."]
   pruneopts = "UT"
-  revision = "3d5d8f294aa03d8e98859feac328afbdf1ae0703"
+  revision = "886a7fbe3eb1c874d46f623bfa70af45f425b3d1"
+  version = "v1.0.0"
 
 [[projects]]
-  branch = "master"
-  digest = "1:183f00c472fb9b2446659618eebf4899872fa267b92f926539411abdc8b941df"
+  digest = "1:bc4393e7d030ef4a548d9643997e2ae9064ed93d7ed140569b27336ee3b77464"
   name = "github.com/hashicorp/go-retryablehttp"
   packages = ["."]
   pruneopts = "UT"
-  revision = "e651d75abec6fbd4f2c09508f72ae7af8a8b7171"
+  revision = "a83ad44d6a5fc343d7c4babf601092b3c189f402"
+  version = "v0.6.2"
 
 [[projects]]
-  branch = "master"
-  digest = "1:45aad874d3c7d5e8610427c81870fb54970b981692930ec2a319ce4cb89d7a00"
+  digest = "1:7b893c9e1181e224506c523777dea0d16f4bd20a7627b100cc800e14229f405c"
   name = "github.com/hashicorp/go-rootcerts"
   packages = ["."]
   pruneopts = "UT"
-  revision = "6bb64b370b90e7ef1fa532be9e591a81c3493e00"
+  revision = "df8e78a645e18d56ed7bb9ae10ffb8174ab892e2"
+  version = "v1.0.1"
 
 [[projects]]
-  branch = "master"
-  digest = "1:14f2005c31ddf99c4a0f36fc440f8d1ac43224194c7c4a904b3c8f4ba5654d0b"
+  digest = "1:8abc57884881876d02f467bb7d4ed7ce3a58dac3f8f7ba60579ce4ffc6afd7e1"
   name = "github.com/hashicorp/go-sockaddr"
   packages = ["."]
   pruneopts = "UT"
-  revision = "6d291a969b86c4b633730bfc6b8b9d64c3aafed9"
+  revision = "c7188e74f6acae5a989bdc959aa779f8b9f42faf"
+  version = "v1.0.2"
 
 [[projects]]
-  branch = "master"
-  digest = "1:12247a2e99a060cc692f6680e5272c8adf0b8f572e6bce0d7095e624c958a240"
+  digest = "1:ea40c24cdbacd054a6ae9de03e62c5f252479b96c716375aace5c120d68647c8"
   name = "github.com/hashicorp/hcl"
   packages = [
     ".",
@@ -320,7 +325,8 @@
     "json/token",
   ]
   pruneopts = "UT"
-  revision = "ef8a98b0bbce4a65b5aa4c368430a80ddc533168"
+  revision = "8cb6e5b959231cc1119e43259c4a608f9c51a241"
+  version = "v1.0.0"
 
 [[projects]]
   digest = "1:73ee84b6f2e41b5c16ecb76c8a3785cb31f4d45a9842b750be70167a3451584b"
@@ -347,11 +353,11 @@
   version = "v0.3.7"
 
 [[projects]]
-  digest = "1:e22af8c7518e1eab6f2eab2b7d7558927f816262586cd6ed9f349c97a6c285c4"
+  digest = "1:bb81097a5b62634f3e9fec1014657855610c82d19b9a40c17612e32651e35dca"
   name = "github.com/jmespath/go-jmespath"
   packages = ["."]
   pruneopts = "UT"
-  revision = "0b12d6b5"
+  revision = "c2b33e84"
 
 [[projects]]
   digest = "1:709cd2a2c29cc9b89732f6c24846bbb9d6270f28ef5ef2128cc73bd0d6d7bff9"
@@ -362,20 +368,20 @@
   version = "v1.1.7"
 
 [[projects]]
-  branch = "master"
-  digest = "1:8eb17c2ec4df79193ae65b621cd1c0c4697db3bc317fe6afdc76d7f2746abd05"
+  digest = "1:5d231480e1c64a726869bc4142d270184c419749d34f167646baa21008eb0a79"
   name = "github.com/mitchellh/go-homedir"
   packages = ["."]
   pruneopts = "UT"
-  revision = "3864e76763d94a6df2f9960b16a20a33da9f9a66"
+  revision = "af06845cf3004701891bf4fdb884bfe4920b3727"
+  version = "v1.1.0"
 
 [[projects]]
-  branch = "master"
-  digest = "1:5ab79470a1d0fb19b041a624415612f8236b3c06070161a910562f2b2d064355"
+  digest = "1:53bc4cd4914cd7cd52139990d5170d6dc99067ae31c56530621b18b35fc30318"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
   pruneopts = "UT"
-  revision = "f15292f7a699fcc1a38a80977f80a046874ba8ac"
+  revision = "3536a929edddb9a5b34bd6861dc4a9647cb459fe"
+  version = "v1.1.2"
 
 [[projects]]
   digest = "1:33422d238f147d247752996a26574ac48dcf472976eda7f5134015f06bf16563"
@@ -429,7 +435,7 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:6c7a3f738e37a1c7ad3d56122a34932140654d51a57e01f8613cdf3eaf050911"
+  digest = "1:3e5eb9af2330c7a46d64592800813c33adf94305ce53a3fae42191ea18e520e6"
   name = "github.com/pquerna/otp"
   packages = [
     ".",
@@ -437,8 +443,8 @@
     "totp",
   ]
   pruneopts = "UT"
-  revision = "b7b89250c468c06871d3837bee02e2d5c155ae19"
-  version = "v1.0.0"
+  revision = "43bebefda392017900e7a7b237b4c914c6a55b50"
+  version = "v1.2.0"
 
 [[projects]]
   digest = "1:b36a0ede02c4c2aef7df7f91cbbb7bb88a98b5d253509d4f997dda526e50c88c"
@@ -449,12 +455,12 @@
   version = "v1.5.2"
 
 [[projects]]
-  digest = "1:0e792eea6c96ec55ff302ef33886acbaa5006e900fefe82689e88d96439dcd84"
+  digest = "1:6baa565fe16f8657cf93469b2b8a6c61a277827734400d27e44d589547297279"
   name = "github.com/ryanuber/go-glob"
   packages = ["."]
   pruneopts = "UT"
-  revision = "572520ed46dbddaed19ea3d9541bdd0494163693"
-  version = "v0.1"
+  revision = "51a8f68e6c24dc43f1e371749c89a267de4ebc53"
+  version = "v1.0.0"
 
 [[projects]]
   digest = "1:524b71991fc7d9246cc7dc2d9e0886ccb97648091c63e30eef619e6862c955dd"
@@ -485,7 +491,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:fdfd67cb7f3b4d81cd89f6a90e76e50ef54a322bc035a924577048e9c4d57b41"
+  digest = "1:ddaf3e8ac9834e8fb93345a53f02d1104d03395c2d394814d80c0ddb1442036c"
   name = "golang.org/x/crypto"
   packages = [
     "curve25519",
@@ -500,11 +506,11 @@
     "ssh/terminal",
   ]
   pruneopts = "UT"
-  revision = "c126467f60eb25f8f27e5a981f32a87e3965053f"
+  revision = "88343688bb370571259f1a6c98274757b61e3bb1"
 
 [[projects]]
   branch = "master"
-  digest = "1:1f71d110bfc1caef79e72c3606c6110fc4d9b606124fe56bd3c2615325957c3d"
+  digest = "1:9f7eae014eed6507ce24fb893874516db03e911fe745a3fd6cd3adcbc4c7e8c9"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -515,7 +521,7 @@
     "idna",
   ]
   pruneopts = "UT"
-  revision = "a680a1efc54dd51c040b3b5ce4939ea3cf2ea0d1"
+  revision = "c5a3c61f89f3ed696ec36b629ef1b97541165225"
 
 [[projects]]
   branch = "master"
@@ -533,9 +539,10 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:7711a885664a85941a1d9d339f7f12c742cd8f88def90e74f89805508cfca97f"
+  digest = "1:14f5ded65a63708325dc97d7a74e49439ad8f4c2493a7401a5535060ff061267"
   name = "golang.org/x/sys"
   packages = [
+    "cpu",
     "unix",
     "windows",
   ]
@@ -543,13 +550,15 @@
   revision = "c990c680b611ac1aeb7d8f2af94a825f98d69720"
 
 [[projects]]
-  digest = "1:a2ab62866c75542dd18d2b069fec854577a20211d7c0ea6ae746072a1dccdd18"
+  digest = "1:8d8faad6b12a3a4c819a3f9618cb6ee1fa1cfc33253abeeea8b55336721e3405"
   name = "golang.org/x/text"
   packages = [
     "collate",
     "collate/build",
     "internal/colltab",
     "internal/gen",
+    "internal/language",
+    "internal/language/compact",
     "internal/tag",
     "internal/triegen",
     "internal/ucd",
@@ -562,16 +571,16 @@
     "unicode/rangetable",
   ]
   pruneopts = "UT"
-  revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
-  version = "v0.3.0"
+  revision = "342b2e1fbaa52c93f31447ad2c6abc048c63e475"
+  version = "v0.3.2"
 
 [[projects]]
   branch = "master"
-  digest = "1:c9e7a4b4d47c0ed205d257648b0e5b0440880cb728506e318f8ac7cd36270bc4"
+  digest = "1:cdd088b35bbf78713a6861a44a1bbe97e581861b6b8835c7f2211bbeca3671f6"
   name = "golang.org/x/time"
   packages = ["rate"]
   pruneopts = "UT"
-  revision = "fbb02b2291d28baffd63558aa44b4b56f178d650"
+  revision = "c4c64cad1fd0a1a8dab2523e04e61d35308e131e"
 
 [[projects]]
   digest = "1:f8c47e4318ce1e2a96194740c781d47149007409f48bdbd61027b10e1c5394c2"

--- a/test/Gopkg.lock
+++ b/test/Gopkg.lock
@@ -441,12 +441,12 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:2ee0f15eb0fb04f918db7c2dcf39745f40d69f798ef171610a730e8a56aaa4fd"
+  digest = "1:b36a0ede02c4c2aef7df7f91cbbb7bb88a98b5d253509d4f997dda526e50c88c"
   name = "github.com/russross/blackfriday"
   packages = ["."]
   pruneopts = "UT"
-  revision = "d3b5b032dc8e8927d31a5071b56e14c89f045135"
-  version = "v2.0.1"
+  revision = "05f3235734ad95d0016f6a23902f06461fcf567a"
+  version = "v1.5.2"
 
 [[projects]]
   digest = "1:0e792eea6c96ec55ff302ef33886acbaa5006e900fefe82689e88d96439dcd84"
@@ -455,14 +455,6 @@
   pruneopts = "UT"
   revision = "572520ed46dbddaed19ea3d9541bdd0494163693"
   version = "v0.1"
-
-[[projects]]
-  digest = "1:9421f6e9e28ef86933e824b5caff441366f2b69bb281085b9dca40e1f27a1602"
-  name = "github.com/shurcooL/sanitized_anchor_name"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "7bfe4c7ecddb3666a94b053b422cdd8f5aaa3615"
-  version = "v1.0.0"
 
 [[projects]]
   digest = "1:524b71991fc7d9246cc7dc2d9e0886ccb97648091c63e30eef619e6862c955dd"

--- a/test/Gopkg.toml
+++ b/test/Gopkg.toml
@@ -33,6 +33,10 @@
   name = "github.com/hashicorp/vault"
   version = "1.2.3"
 
+[[override]]
+  name = "github.com/russross/blackfriday"
+  version = "1.5.2"
+
 [prune]
   go-tests = true
   unused-packages = true

--- a/test/basic_example_test.go
+++ b/test/basic_example_test.go
@@ -103,7 +103,7 @@ func TestGlobalTableExample(t *testing.T) {
 				"key_name":                os.Getenv("TEST_KEY_NAME"),
 				"vault_version":           os.Getenv("TEST_VAULT_VERSION"),
 				"project":                 projectName,
-				"acme_server":             "https://acme-staging.api.letsencrypt.org/directory",
+				"acme_server":             "https://acme-staging-v02.api.letsencrypt.org/directory",
 				"lb_internal":             false,
 				"dynamodb_replica_region": "eu-west-2",
 			},

--- a/test/basic_example_test.go
+++ b/test/basic_example_test.go
@@ -2,16 +2,16 @@ package test
 
 import (
 	"fmt"
+	"net/http"
 	"os"
 	"testing"
 	"time"
-	"net/http"
 
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/gruntwork-io/terratest/modules/terraform"
-	"github.com/gruntwork-io/terratest/modules/test-structure"
+	test_structure "github.com/gruntwork-io/terratest/modules/test-structure"
 	"github.com/hashicorp/vault/api"
 )
 
@@ -58,7 +58,7 @@ func TestBasicExample(t *testing.T) {
 				"key_name":       os.Getenv("TEST_KEY_NAME"),
 				"vault_version":  os.Getenv("TEST_VAULT_VERSION"),
 				"project":        projectName,
-				"acme_server":    "https://acme-staging.api.letsencrypt.org/directory",
+				"acme_server":    "https://acme-staging-v02.api.letsencrypt.org/directory",
 				"lb_internal":    false,
 			},
 

--- a/vault/alb.tf
+++ b/vault/alb.tf
@@ -24,6 +24,10 @@ resource "aws_lb_target_group" "main" {
     path              = "/v1/sys/health"
     healthy_threshold = 4
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_lb_listener" "https" {
@@ -55,6 +59,10 @@ resource "aws_lb_target_group" "vault1" {
     protocol          = "HTTPS"
     path              = "/"
     healthy_threshold = 4
+  }
+
+  lifecycle {
+    create_before_destroy = true
   }
 }
 
@@ -96,6 +104,10 @@ resource "aws_lb_target_group" "vault2" {
     protocol          = "HTTPS"
     path              = "/"
     healthy_threshold = 4
+  }
+
+  lifecycle {
+    create_before_destroy = true
   }
 }
 

--- a/vault/alb.tf
+++ b/vault/alb.tf
@@ -3,6 +3,7 @@ resource "aws_lb" "alb" {
   internal        = var.lb_internal
   subnets         = var.lb_subnets
   security_groups = [aws_security_group.alb.id]
+  tags            = local.tags
 }
 
 resource "aws_lb_target_group" "main" {
@@ -10,6 +11,7 @@ resource "aws_lb_target_group" "main" {
   port     = 8200
   protocol = "HTTPS"
   vpc_id   = var.vpc_id
+  tags     = local.tags
 
   stickiness {
     enabled = false
@@ -41,6 +43,7 @@ resource "aws_lb_target_group" "vault1" {
   port     = 8200
   protocol = "HTTPS"
   vpc_id   = var.vpc_id
+  tags     = local.tags
 
   stickiness {
     enabled = false
@@ -81,6 +84,7 @@ resource "aws_lb_target_group" "vault2" {
   port     = 8200
   protocol = "HTTPS"
   vpc_id   = var.vpc_id
+  tags     = local.tags
 
   stickiness {
     enabled = false

--- a/vault/alb.tf
+++ b/vault/alb.tf
@@ -1,39 +1,53 @@
-module "alb" {
-  source                       = "github.com/skyscrapers/terraform-loadbalancers//alb?ref=3.1.2"
-  name                         = "vault"
-  environment                  = "${var.environment}"
-  project                      = "${var.project}"
-  vpc_id                       = "${var.vpc_id}"
-  subnets                      = "${var.lb_subnets}"
-  enable_http_listener         = false
-  enable_https_listener        = true
-  https_certificate_arn        = "${var.acm_arn}"
-  target_security_groups       = ["${aws_security_group.vault.id}"]
-  target_port                  = 8200
-  target_protocol              = "HTTPS"
-  target_health_path           = "/v1/sys/health"
-  target_health_protocol       = "HTTPS"
-  target_security_groups_count = 1
-  internal                     = "${var.lb_internal}"
-
-  target_stickiness = [{
-    enabled = false
-    type    = "lb_cookie"
-  }]
+resource "aws_lb" "alb" {
+  name            = "vault-${var.project}-${var.environment}"
+  internal        = var.lb_internal
+  subnets         = var.lb_subnets
+  security_groups = [aws_security_group.alb.id]
 }
 
-resource "aws_lb_target_group" "vault1" {
-  name     = "vault1-group"
+resource "aws_lb_target_group" "main" {
+  name     = "vault-main-${var.project}-${var.environment}"
   port     = 8200
   protocol = "HTTPS"
-  vpc_id   = "${var.vpc_id}"
+  vpc_id   = var.vpc_id
 
-  stickiness = {
+  stickiness {
     enabled = false
     type    = "lb_cookie"
   }
 
-  health_check = {
+  health_check {
+    matcher           = 200
+    protocol          = "HTTPS"
+    path              = "/v1/sys/health"
+    healthy_threshold = 4
+  }
+}
+
+resource "aws_lb_listener" "https" {
+  load_balancer_arn = aws_lb.alb.arn
+  port              = 443
+  protocol          = "HTTPS"
+  certificate_arn   = var.acm_arn
+
+  default_action {
+    target_group_arn = aws_lb_target_group.main.arn
+    type             = "forward"
+  }
+}
+
+resource "aws_lb_target_group" "vault1" {
+  name     = "vault1-${var.project}-${var.environment}"
+  port     = 8200
+  protocol = "HTTPS"
+  vpc_id   = var.vpc_id
+
+  stickiness {
+    enabled = false
+    type    = "lb_cookie"
+  }
+
+  health_check {
     matcher           = "404"
     protocol          = "HTTPS"
     path              = "/"
@@ -42,38 +56,38 @@ resource "aws_lb_target_group" "vault1" {
 }
 
 resource "aws_lb_target_group_attachment" "vault1" {
-  target_group_arn = "${aws_lb_target_group.vault1.arn}"
-  target_id        = "${module.vault1.instance_ids[0]}"
+  target_group_arn = aws_lb_target_group.vault1.arn
+  target_id        = module.vault1.instance_ids[0]
   port             = 8200
 }
 
 resource "aws_lb_listener_rule" "vault1" {
-  listener_arn = "${module.alb.https_listener_id}"
+  listener_arn = aws_lb_listener.https.arn
   priority     = 10
 
   action {
     type             = "forward"
-    target_group_arn = "${aws_lb_target_group.vault1.arn}"
+    target_group_arn = aws_lb_target_group.vault1.arn
   }
 
   condition {
     field  = "host-header"
-    values = ["${aws_route53_record.vault1.name}"]
+    values = [aws_route53_record.vault1.name]
   }
 }
 
 resource "aws_lb_target_group" "vault2" {
-  name     = "vault2-group"
+  name     = "vault2-${var.project}-${var.environment}"
   port     = 8200
   protocol = "HTTPS"
-  vpc_id   = "${var.vpc_id}"
+  vpc_id   = var.vpc_id
 
-  stickiness = {
+  stickiness {
     enabled = false
     type    = "lb_cookie"
   }
 
-  health_check = {
+  health_check {
     matcher           = "404"
     protocol          = "HTTPS"
     path              = "/"
@@ -82,34 +96,34 @@ resource "aws_lb_target_group" "vault2" {
 }
 
 resource "aws_lb_target_group_attachment" "vault2" {
-  target_group_arn = "${aws_lb_target_group.vault2.arn}"
-  target_id        = "${module.vault2.instance_ids[0]}"
+  target_group_arn = aws_lb_target_group.vault2.arn
+  target_id        = module.vault2.instance_ids[0]
   port             = 8200
 }
 
 resource "aws_lb_listener_rule" "vault2" {
-  listener_arn = "${module.alb.https_listener_id}"
+  listener_arn = aws_lb_listener.https.arn
   priority     = 11
 
   action {
     type             = "forward"
-    target_group_arn = "${aws_lb_target_group.vault2.arn}"
+    target_group_arn = aws_lb_target_group.vault2.arn
   }
 
   condition {
     field  = "host-header"
-    values = ["${aws_route53_record.vault2.name}"]
+    values = [aws_route53_record.vault2.name]
   }
 }
 
 resource "aws_lb_target_group_attachment" "vault1_main" {
-  target_group_arn = "${module.alb.target_group_arn}"
-  target_id        = "${module.vault1.instance_ids[0]}"
+  target_group_arn = aws_lb_target_group.main.arn
+  target_id        = module.vault1.instance_ids[0]
   port             = 8200
 }
 
 resource "aws_lb_target_group_attachment" "vault2_main" {
-  target_group_arn = "${module.alb.target_group_arn}"
-  target_id        = "${module.vault2.instance_ids[0]}"
+  target_group_arn = aws_lb_target_group.main.arn
+  target_id        = module.vault2.instance_ids[0]
   port             = 8200
 }

--- a/vault/alb.tf
+++ b/vault/alb.tf
@@ -1,12 +1,12 @@
 resource "aws_lb" "alb" {
-  name            = "vault-${var.project}-${var.environment}"
+  name            = "vault-${var.environment}-${var.project}-alb"
   internal        = var.lb_internal
   subnets         = var.lb_subnets
   security_groups = [aws_security_group.alb.id]
 }
 
 resource "aws_lb_target_group" "main" {
-  name     = "vault-main-${var.project}-${var.environment}"
+  name     = "vault-main-${var.environment}-${var.project}"
   port     = 8200
   protocol = "HTTPS"
   vpc_id   = var.vpc_id
@@ -37,7 +37,7 @@ resource "aws_lb_listener" "https" {
 }
 
 resource "aws_lb_target_group" "vault1" {
-  name     = "vault1-${var.project}-${var.environment}"
+  name     = "vault1-${var.environment}-${var.project}"
   port     = 8200
   protocol = "HTTPS"
   vpc_id   = var.vpc_id
@@ -77,7 +77,7 @@ resource "aws_lb_listener_rule" "vault1" {
 }
 
 resource "aws_lb_target_group" "vault2" {
-  name     = "vault2-${var.project}-${var.environment}"
+  name     = "vault2-${var.environment}-${var.project}"
   port     = 8200
   protocol = "HTTPS"
   vpc_id   = var.vpc_id

--- a/vault/cloud-config.tf
+++ b/vault/cloud-config.tf
@@ -1,5 +1,5 @@
 locals {
-  dynamodb_table_name = "${var.enable_dynamodb_replica_table ? join("", aws_dynamodb_global_table.vault_global_table.*.id) : module.main_dynamodb_table.table_name}"
+  dynamodb_table_name = var.enable_dynamodb_replica_table ? join("", aws_dynamodb_global_table.vault_global_table.*.id) : module.main_dynamodb_table.table_name
 }
 
 data "template_cloudinit_config" "vault1" {
@@ -8,17 +8,17 @@ data "template_cloudinit_config" "vault1" {
 
   part {
     content_type = "text/cloud-config"
-    content      = "${data.template_file.cloudconfig_vault1.rendered}"
+    content      = data.template_file.cloudconfig_vault1.rendered
   }
 
   part {
     content_type = "text/x-shellscript"
-    content      = "${data.template_file.install.rendered}"
+    content      = data.template_file.install.rendered
   }
 
   part {
     content_type = "text/x-shellscript"
-    content      = "${var.teleport_auth_server == "" ? "" : module.teleport_vault1.teleport_bootstrap_script}"
+    content      = var.teleport_auth_server == null ? "" : module.teleport_vault1.teleport_bootstrap_script
   }
 }
 
@@ -28,71 +28,71 @@ data "template_cloudinit_config" "vault2" {
 
   part {
     content_type = "text/cloud-config"
-    content      = "${data.template_file.cloudconfig_vault2.rendered}"
+    content      = data.template_file.cloudconfig_vault2.rendered
   }
 
   part {
     content_type = "text/x-shellscript"
-    content      = "${data.template_file.install.rendered}"
+    content      = data.template_file.install.rendered
   }
 
   part {
     content_type = "text/x-shellscript"
-    content      = "${var.teleport_auth_server == "" ? "" : module.teleport_vault2.teleport_bootstrap_script}"
+    content      = var.teleport_auth_server == null ? "" : module.teleport_vault2.teleport_bootstrap_script
   }
 }
 
 data "template_file" "cloudconfig_vault1" {
-  template = "${file("${path.module}/templates/configure.yaml.tpl")}"
+  template = file("${path.module}/templates/configure.yaml.tpl")
 
-  vars {
+  vars = {
     vault_dns           = "vault1.${var.dns_root}"
-    vault_nproc         = "${var.vault_nproc}"
+    vault_nproc         = var.vault_nproc
     vault_cluster_dns   = "vault.${var.dns_root}"
-    teleport_config     = "${var.teleport_auth_server == "" ? "" : module.teleport_vault1.teleport_config_cloudinit}"
-    teleport_service    = "${var.teleport_auth_server == "" ? "" : module.teleport_vault1.teleport_service_cloudinit}"
-    dynamodb_table_name = "${local.dynamodb_table_name}"
-    acme_server         = "${var.acme_server}"
-    le_email            = "${var.le_email}"
-    region              = "${data.aws_region.main.name}"
-    enable_ui           = "${var.enable_ui ? "true" : "false"}"
+    teleport_config     = var.teleport_auth_server == null ? "" : module.teleport_vault1.teleport_config_cloudinit
+    teleport_service    = var.teleport_auth_server == null ? "" : module.teleport_vault1.teleport_service_cloudinit
+    dynamodb_table_name = local.dynamodb_table_name
+    acme_server         = var.acme_server
+    le_email            = var.le_email
+    region              = data.aws_region.main.name
+    enable_ui           = var.enable_ui ? "true" : "false"
   }
 }
 
 data "template_file" "cloudconfig_vault2" {
-  template = "${file("${path.module}/templates/configure.yaml.tpl")}"
+  template = file("${path.module}/templates/configure.yaml.tpl")
 
-  vars {
+  vars = {
     vault_dns           = "vault2.${var.dns_root}"
-    vault_nproc         = "${var.vault_nproc}"
+    vault_nproc         = var.vault_nproc
     vault_cluster_dns   = "vault.${var.dns_root}"
-    teleport_config     = "${var.teleport_auth_server == "" ? "" : module.teleport_vault2.teleport_config_cloudinit}"
-    teleport_service    = "${var.teleport_auth_server == "" ? "" : module.teleport_vault2.teleport_service_cloudinit}"
-    dynamodb_table_name = "${local.dynamodb_table_name}"
-    acme_server         = "${var.acme_server}"
-    le_email            = "${var.le_email}"
-    region              = "${data.aws_region.main.name}"
-    enable_ui           = "${var.enable_ui ? "true" : "false"}"
+    teleport_config     = var.teleport_auth_server == null ? "" : module.teleport_vault2.teleport_config_cloudinit
+    teleport_service    = var.teleport_auth_server == null ? "" : module.teleport_vault2.teleport_service_cloudinit
+    dynamodb_table_name = local.dynamodb_table_name
+    acme_server         = var.acme_server
+    le_email            = var.le_email
+    region              = data.aws_region.main.name
+    enable_ui           = var.enable_ui ? "true" : "false"
   }
 }
 
 data "template_file" "install" {
-  template = "${file("${path.module}/templates/install.sh.tpl")}"
+  template = file("${path.module}/templates/install.sh.tpl")
 
-  vars {
+  vars = {
     download_url_vault    = "https://releases.hashicorp.com/vault/${var.vault_version}/vault_${var.vault_version}_linux_386.zip"
     download_url_teleport = "https://get.gravitational.com/teleport-v${var.teleport_version}-linux-amd64-bin.tar.gz"
-    teleport_auth_server  = "${var.teleport_auth_server}"
+    teleport_auth_server  = var.teleport_auth_server
   }
 }
 
 module "teleport_vault1" {
-  source      = "github.com/skyscrapers/terraform-teleport//teleport-bootstrap-script?ref=3.3.5"
-  auth_server = "${var.teleport_auth_server}"
-  auth_token  = "${var.teleport_token_1}"
+  source      = "github.com/skyscrapers/terraform-teleport//teleport-bootstrap-script?ref=5.0.1"
+  auth_server = var.teleport_auth_server
+  auth_token  = var.teleport_token_1
   function    = "vault1"
-  environment = "${var.environment}"
-  project     = "${var.project}"
+  environment = var.environment
+  project     = var.project
 
   additional_labels = [
     "vault_version: \"${var.vault_version}\"",
@@ -101,12 +101,12 @@ module "teleport_vault1" {
 }
 
 module "teleport_vault2" {
-  source      = "github.com/skyscrapers/terraform-teleport//teleport-bootstrap-script?ref=3.3.5"
-  auth_server = "${var.teleport_auth_server}"
-  auth_token  = "${var.teleport_token_2}"
+  source      = "github.com/skyscrapers/terraform-teleport//teleport-bootstrap-script?ref=5.0.1"
+  auth_server = var.teleport_auth_server
+  auth_token  = var.teleport_token_2
   function    = "vault2"
-  environment = "${var.environment}"
-  project     = "${var.project}"
+  environment = var.environment
+  project     = var.project
 
   additional_labels = [
     "vault_version: \"${var.vault_version}\"",

--- a/vault/cloud-config.tf
+++ b/vault/cloud-config.tf
@@ -82,14 +82,14 @@ data "template_file" "install" {
   vars = {
     download_url_vault    = "https://releases.hashicorp.com/vault/${var.vault_version}/vault_${var.vault_version}_linux_386.zip"
     download_url_teleport = "https://get.gravitational.com/teleport-v${var.teleport_version}-linux-amd64-bin.tar.gz"
-    teleport_auth_server  = var.teleport_auth_server
+    teleport_auth_server  = var.teleport_auth_server == null ? "" : var.teleport_auth_server
   }
 }
 
 module "teleport_vault1" {
   source      = "github.com/skyscrapers/terraform-teleport//teleport-bootstrap-script?ref=5.0.1"
-  auth_server = var.teleport_auth_server
-  auth_token  = var.teleport_token_1
+  auth_server = var.teleport_auth_server == null ? "" : var.teleport_auth_server
+  auth_token  = var.teleport_token_1 == null ? "" : var.teleport_token_1
   function    = "vault1"
   environment = var.environment
   project     = var.project
@@ -102,8 +102,8 @@ module "teleport_vault1" {
 
 module "teleport_vault2" {
   source      = "github.com/skyscrapers/terraform-teleport//teleport-bootstrap-script?ref=5.0.1"
-  auth_server = var.teleport_auth_server
-  auth_token  = var.teleport_token_2
+  auth_server = var.teleport_auth_server == null ? "" : var.teleport_auth_server
+  auth_token  = var.teleport_token_2 == null ? "" : var.teleport_token_2
   function    = "vault2"
   environment = var.environment
   project     = var.project

--- a/vault/dynamodb.tf
+++ b/vault/dynamodb.tf
@@ -24,7 +24,9 @@ module "replica_dynamodb_table" {
 
 resource "aws_dynamodb_global_table" "vault_global_table" {
   count = var.enable_dynamodb_replica_table ? 1 : 0
-  name  = module.main_dynamodb_table.table_name
+
+  # Fake dependency for both child dynamodb tables
+  name = [module.main_dynamodb_table.table_name, module.replica_dynamodb_table.table_name][0]
 
   replica {
     region_name = data.aws_region.main.name

--- a/vault/dynamodb.tf
+++ b/vault/dynamodb.tf
@@ -1,6 +1,5 @@
 module "main_dynamodb_table" {
-  source = "/Users/iuri/projects/skyscrapers/terraform-modules/terraform-vault/dynamodb-table"
-  # source                        = "../dynamodb-table"
+  source                        = "../dynamodb-table"
   enable                        = true
   dynamodb_table_name_override  = var.dynamodb_table_name_override
   environment                   = var.environment
@@ -9,8 +8,7 @@ module "main_dynamodb_table" {
 }
 
 module "replica_dynamodb_table" {
-  source = "/Users/iuri/projects/skyscrapers/terraform-modules/terraform-vault/dynamodb-table"
-  # source                        = "../dynamodb-table"
+  source                        = "../dynamodb-table"
   enable                        = var.enable_dynamodb_replica_table
   dynamodb_table_name_override  = var.dynamodb_table_name_override
   environment                   = var.environment

--- a/vault/dynamodb.tf
+++ b/vault/dynamodb.tf
@@ -5,6 +5,7 @@ module "main_dynamodb_table" {
   environment                   = var.environment
   project                       = var.project
   enable_point_in_time_recovery = var.enable_point_in_time_recovery
+  tags                          = local.tags
 }
 
 module "replica_dynamodb_table" {
@@ -14,6 +15,7 @@ module "replica_dynamodb_table" {
   environment                   = var.environment
   project                       = var.project
   enable_point_in_time_recovery = var.enable_point_in_time_recovery
+  tags                          = local.tags
 
   providers = {
     aws = aws.replica

--- a/vault/dynamodb.tf
+++ b/vault/dynamodb.tf
@@ -6,11 +6,6 @@ module "main_dynamodb_table" {
   environment                   = var.environment
   project                       = var.project
   enable_point_in_time_recovery = var.enable_point_in_time_recovery
-  dynamodb_max_read_capacity    = var.dynamodb_max_read_capacity
-  dynamodb_min_read_capacity    = var.dynamodb_min_read_capacity
-  dynamodb_max_write_capacity   = var.dynamodb_max_write_capacity
-  dynamodb_min_write_capacity   = var.dynamodb_min_write_capacity
-  enable_dynamodb_autoscaling   = var.enable_dynamodb_autoscaling
 }
 
 module "replica_dynamodb_table" {
@@ -21,11 +16,6 @@ module "replica_dynamodb_table" {
   environment                   = var.environment
   project                       = var.project
   enable_point_in_time_recovery = var.enable_point_in_time_recovery
-  dynamodb_max_read_capacity    = var.replica_dynamodb_max_read_capacity
-  dynamodb_min_read_capacity    = var.replica_dynamodb_min_read_capacity
-  dynamodb_max_write_capacity   = var.dynamodb_max_write_capacity
-  dynamodb_min_write_capacity   = var.dynamodb_min_write_capacity
-  enable_dynamodb_autoscaling   = var.enable_dynamodb_autoscaling
 
   providers = {
     aws = aws.replica
@@ -34,19 +24,7 @@ module "replica_dynamodb_table" {
 
 resource "aws_dynamodb_global_table" "vault_global_table" {
   count = var.enable_dynamodb_replica_table ? 1 : 0
-
-  # A DynamoDB global table requires that the autoscaling on all replica tables are enabled
-  # This will force such dependency as "depends_on" can't be used on modules
-  name = index(
-    [
-      "needle",
-      module.main_dynamodb_table.write_autoscaling_policy_arn,
-      module.replica_dynamodb_table.write_autoscaling_policy_arn,
-      module.main_dynamodb_table.read_autoscaling_policy_arn,
-      module.replica_dynamodb_table.read_autoscaling_policy_arn,
-    ],
-    "needle",
-  ) == 0 ? module.main_dynamodb_table.table_name : ""
+  name  = module.main_dynamodb_table.table_name
 
   replica {
     region_name = data.aws_region.main.name

--- a/vault/dynamodb.tf
+++ b/vault/dynamodb.tf
@@ -1,53 +1,58 @@
 module "main_dynamodb_table" {
-  source                        = "../dynamodb-table"
+  source = "/Users/iuri/projects/skyscrapers/terraform-modules/terraform-vault/dynamodb-table"
+  # source                        = "../dynamodb-table"
   enable                        = true
-  dynamodb_table_name_override  = "${var.dynamodb_table_name_override}"
-  environment                   = "${var.environment}"
-  project                       = "${var.project}"
-  enable_point_in_time_recovery = "${var.enable_point_in_time_recovery}"
-  dynamodb_max_read_capacity    = "${var.dynamodb_max_read_capacity}"
-  dynamodb_min_read_capacity    = "${var.dynamodb_min_read_capacity}"
-  dynamodb_max_write_capacity   = "${var.dynamodb_max_write_capacity}"
-  dynamodb_min_write_capacity   = "${var.dynamodb_min_write_capacity}"
-  enable_dynamodb_autoscaling   = "${var.enable_dynamodb_autoscaling}"
+  dynamodb_table_name_override  = var.dynamodb_table_name_override
+  environment                   = var.environment
+  project                       = var.project
+  enable_point_in_time_recovery = var.enable_point_in_time_recovery
+  dynamodb_max_read_capacity    = var.dynamodb_max_read_capacity
+  dynamodb_min_read_capacity    = var.dynamodb_min_read_capacity
+  dynamodb_max_write_capacity   = var.dynamodb_max_write_capacity
+  dynamodb_min_write_capacity   = var.dynamodb_min_write_capacity
+  enable_dynamodb_autoscaling   = var.enable_dynamodb_autoscaling
 }
 
 module "replica_dynamodb_table" {
-  source                        = "../dynamodb-table"
-  enable                        = "${var.enable_dynamodb_replica_table}"
-  dynamodb_table_name_override  = "${var.dynamodb_table_name_override}"
-  environment                   = "${var.environment}"
-  project                       = "${var.project}"
-  enable_point_in_time_recovery = "${var.enable_point_in_time_recovery}"
-  dynamodb_max_read_capacity    = "${var.replica_dynamodb_max_read_capacity}"
-  dynamodb_min_read_capacity    = "${var.replica_dynamodb_min_read_capacity}"
-  dynamodb_max_write_capacity   = "${var.dynamodb_max_write_capacity}"
-  dynamodb_min_write_capacity   = "${var.dynamodb_min_write_capacity}"
-  enable_dynamodb_autoscaling   = "${var.enable_dynamodb_autoscaling}"
+  source = "/Users/iuri/projects/skyscrapers/terraform-modules/terraform-vault/dynamodb-table"
+  # source                        = "../dynamodb-table"
+  enable                        = var.enable_dynamodb_replica_table
+  dynamodb_table_name_override  = var.dynamodb_table_name_override
+  environment                   = var.environment
+  project                       = var.project
+  enable_point_in_time_recovery = var.enable_point_in_time_recovery
+  dynamodb_max_read_capacity    = var.replica_dynamodb_max_read_capacity
+  dynamodb_min_read_capacity    = var.replica_dynamodb_min_read_capacity
+  dynamodb_max_write_capacity   = var.dynamodb_max_write_capacity
+  dynamodb_min_write_capacity   = var.dynamodb_min_write_capacity
+  enable_dynamodb_autoscaling   = var.enable_dynamodb_autoscaling
 
   providers = {
-    aws = "aws.replica"
+    aws = aws.replica
   }
 }
 
 resource "aws_dynamodb_global_table" "vault_global_table" {
-  count = "${var.enable_dynamodb_replica_table ? 1 : 0}"
+  count = var.enable_dynamodb_replica_table ? 1 : 0
 
   # A DynamoDB global table requires that the autoscaling on all replica tables are enabled
   # This will force such dependency as "depends_on" can't be used on modules
-  name  = "${index(list(
+  name = index(
+    [
+      "needle",
+      module.main_dynamodb_table.write_autoscaling_policy_arn,
+      module.replica_dynamodb_table.write_autoscaling_policy_arn,
+      module.main_dynamodb_table.read_autoscaling_policy_arn,
+      module.replica_dynamodb_table.read_autoscaling_policy_arn,
+    ],
     "needle",
-    module.main_dynamodb_table.write_autoscaling_policy_arn,
-    module.replica_dynamodb_table.write_autoscaling_policy_arn,
-    module.main_dynamodb_table.read_autoscaling_policy_arn,
-    module.replica_dynamodb_table.read_autoscaling_policy_arn
-  ), "needle") == 0 ? module.main_dynamodb_table.table_name : ""}"
+  ) == 0 ? module.main_dynamodb_table.table_name : ""
 
   replica {
-    region_name = "${data.aws_region.main.name}"
+    region_name = data.aws_region.main.name
   }
 
   replica {
-    region_name = "${data.aws_region.replica.name}"
+    region_name = data.aws_region.replica.name
   }
 }

--- a/vault/iam.tf
+++ b/vault/iam.tf
@@ -95,15 +95,15 @@ data "aws_iam_policy_document" "vault" {
 resource "aws_iam_policy" "vault" {
   name   = "vault_instance_policy_${var.environment}"
   path   = "/"
-  policy = "${data.aws_iam_policy_document.vault.json}"
+  policy = data.aws_iam_policy_document.vault.json
 }
 
 resource "aws_iam_role_policy_attachment" "vault1" {
-  role       = "${module.vault1.role_id}"
-  policy_arn = "${aws_iam_policy.vault.arn}"
+  role       = module.vault1.role_id
+  policy_arn = aws_iam_policy.vault.arn
 }
 
 resource "aws_iam_role_policy_attachment" "vault2" {
-  role       = "${module.vault2.role_id}"
-  policy_arn = "${aws_iam_policy.vault.arn}"
+  role       = module.vault2.role_id
+  policy_arn = aws_iam_policy.vault.arn
 }

--- a/vault/instances.tf
+++ b/vault/instances.tf
@@ -1,31 +1,31 @@
 locals {
-  security_groups = "${compact(list(aws_security_group.vault.id, var.teleport_node_sg))}"
+  security_groups = compact([aws_security_group.vault.id, var.teleport_node_sg])
 }
 
 module "vault1" {
-  source        = "github.com/skyscrapers/terraform-instances//instance?ref=2.3.8"
-  project       = "${var.project}"
-  environment   = "${var.environment}"
+  source        = "github.com/skyscrapers/terraform-instances//instance?ref=3.0.2"
+  project       = var.project
+  environment   = var.environment
   name          = "vault1"
-  sgs           = "${local.security_groups}"
-  subnets       = ["${var.vault1_subnet}"]
-  key_name      = "${var.key_name}"
-  ami           = "${var.ami}"
-  instance_type = "${var.instance_type}"
-  user_data     = ["${data.template_cloudinit_config.vault1.rendered}"]
-  cpu_credits   = "${var.ec2_instances_cpu_credits}"
+  sgs           = local.security_groups
+  subnets       = [var.vault1_subnet]
+  key_name      = var.key_name
+  ami           = var.ami
+  instance_type = var.instance_type
+  user_data     = [data.template_cloudinit_config.vault1.rendered]
+  cpu_credits   = var.ec2_instances_cpu_credits
 }
 
 module "vault2" {
-  source        = "github.com/skyscrapers/terraform-instances//instance?ref=2.3.8"
-  project       = "${var.project}"
-  environment   = "${var.environment}"
+  source        = "github.com/skyscrapers/terraform-instances//instance?ref=3.0.2"
+  project       = var.project
+  environment   = var.environment
   name          = "vault2"
-  sgs           = "${local.security_groups}"
-  subnets       = ["${var.vault2_subnet}"]
-  key_name      = "${var.key_name}"
-  ami           = "${var.ami}"
-  instance_type = "${var.instance_type}"
-  user_data     = ["${data.template_cloudinit_config.vault2.rendered}"]
-  cpu_credits   = "${var.ec2_instances_cpu_credits}"
+  sgs           = local.security_groups
+  subnets       = [var.vault2_subnet]
+  key_name      = var.key_name
+  ami           = var.ami
+  instance_type = var.instance_type
+  user_data     = [data.template_cloudinit_config.vault2.rendered]
+  cpu_credits   = var.ec2_instances_cpu_credits
 }

--- a/vault/main.tf
+++ b/vault/main.tf
@@ -9,5 +9,5 @@ data "aws_caller_identity" "current" {}
 data "aws_region" "main" {}
 
 data "aws_region" "replica" {
-  provider = "aws.replica"
+  provider = aws.replica
 }

--- a/vault/main.tf
+++ b/vault/main.tf
@@ -11,3 +11,10 @@ data "aws_region" "main" {}
 data "aws_region" "replica" {
   provider = aws.replica
 }
+
+locals {
+  tags = {
+    Environment = var.environment
+    Project     = var.project
+  }
+}

--- a/vault/outputs.tf
+++ b/vault/outputs.tf
@@ -1,99 +1,99 @@
 output "sg_id" {
   description = "The vault security-group id"
-  value       = "${aws_security_group.vault.id}"
+  value       = aws_security_group.vault.id
 }
 
 output "vault_route53_record" {
   description = "The main vault route53 record id"
-  value       = "${aws_route53_record.vault.id}"
+  value       = aws_route53_record.vault.id
 }
 
 output "vault1_route53_record" {
   description = "The vault1 route53 record id"
-  value       = "${aws_route53_record.vault1.id}"
+  value       = aws_route53_record.vault1.id
 }
 
 output "vault2_route53_record" {
   description = "The vault2 route53 record id"
-  value       = "${aws_route53_record.vault1.id}"
+  value       = aws_route53_record.vault1.id
 }
 
 output "vault1_instance_id" {
   description = "The vault1 instance ID"
-  value       = "${module.vault1.instance_ids[0]}"
+  value       = module.vault1.instance_ids[0]
 }
 
 output "vault2_instance_id" {
   description = "The vault2 instance ID"
-  value       = "${module.vault2.instance_ids[0]}"
+  value       = module.vault2.instance_ids[0]
 }
 
 output "vault1_role_id" {
   description = "The vault1 instance-role ID"
-  value       = "${module.vault1.role_id}"
+  value       = module.vault1.role_id
 }
 
 output "vault1_role_name" {
   description = "The vault1 instance-role name"
-  value       = "${module.vault1.role_name}"
+  value       = module.vault1.role_name
 }
 
 output "vault2_role_id" {
   description = "The vault2 instance-role ID"
-  value       = "${module.vault2.role_id}"
+  value       = module.vault2.role_id
 }
 
 output "vault2_role_name" {
   description = "The vault2 instance-role name"
-  value       = "${module.vault2.role_name}"
+  value       = module.vault2.role_name
 }
 
 output "iam_policy" {
   description = "The iam policy ARN used for vault"
-  value       = "${aws_iam_policy.vault.arn}"
+  value       = aws_iam_policy.vault.arn
 }
 
 output "alb_main_target_group" {
-  description = "The default alb target group ARN"
-  value       = "${module.alb.target_group_arn}"
+  description = "The main ALB target group ARN"
+  value       = aws_lb_target_group.main.arn
 }
 
 output "alb_vault1_target_group" {
   description = "The vault1 target group ARN"
-  value       = "${aws_lb_target_group.vault1.arn}"
+  value       = aws_lb_target_group.vault1.arn
 }
 
 output "alb_vault2_target_group" {
   description = "The vault2 target group ARN"
-  value       = "${aws_lb_target_group.vault2.arn}"
+  value       = aws_lb_target_group.vault2.arn
 }
 
 output "alb_sg_id" {
   description = "The alb security group ID"
-  value       = "${module.alb.sg_id}"
+  value       = aws_security_group.alb.id
 }
 
 output "alb_id" {
   description = "The alb id"
-  value       = "${module.alb.id}"
+  value       = aws_lb.alb.id
 }
 
 output "alb_arn" {
   description = "The alb ARN"
-  value       = "${module.alb.arn}"
+  value       = aws_lb.alb.arn
 }
 
 output "dynamodb_table_name" {
   description = "The Vault dynamodb table name"
-  value       = "${local.dynamodb_table_name}"
+  value       = local.dynamodb_table_name
 }
 
 output "main_dynamodb_table_region" {
   description = "Region where the main DynamoDB table will be created"
-  value       = "${data.aws_region.main.name}"
+  value       = data.aws_region.main.name
 }
 
 output "replica_dynamodb_table_region" {
   description = "Region where the replica DynamoDB table will be created, if enabled"
-  value       = "${data.aws_region.replica.name}"
+  value       = data.aws_region.replica.name
 }

--- a/vault/r53.tf
+++ b/vault/r53.tf
@@ -1,39 +1,39 @@
 data "aws_route53_zone" "root" {
-  name = "${var.dns_root}"
+  name = var.dns_root
 }
 
 resource "aws_route53_record" "vault" {
-  zone_id = "${data.aws_route53_zone.root.zone_id}"
+  zone_id = data.aws_route53_zone.root.zone_id
   name    = "vault.${data.aws_route53_zone.root.name}"
   type    = "A"
 
   alias {
-    name                   = "${module.alb.dns_name}"
-    zone_id                = "${module.alb.zone_id}"
+    name                   = aws_lb.alb.dns_name
+    zone_id                = aws_lb.alb.zone_id
     evaluate_target_health = false
   }
 }
 
 resource "aws_route53_record" "vault1" {
-  zone_id = "${data.aws_route53_zone.root.zone_id}"
+  zone_id = data.aws_route53_zone.root.zone_id
   name    = "vault1.${data.aws_route53_zone.root.name}"
   type    = "A"
 
   alias {
-    name                   = "${module.alb.dns_name}"
-    zone_id                = "${module.alb.zone_id}"
+    name                   = aws_lb.alb.dns_name
+    zone_id                = aws_lb.alb.zone_id
     evaluate_target_health = false
   }
 }
 
 resource "aws_route53_record" "vault2" {
-  zone_id = "${data.aws_route53_zone.root.zone_id}"
+  zone_id = data.aws_route53_zone.root.zone_id
   name    = "vault2.${data.aws_route53_zone.root.name}"
   type    = "A"
 
   alias {
-    name                   = "${module.alb.dns_name}"
-    zone_id                = "${module.alb.zone_id}"
+    name                   = aws_lb.alb.dns_name
+    zone_id                = aws_lb.alb.zone_id
     evaluate_target_health = false
   }
 }

--- a/vault/sg.tf
+++ b/vault/sg.tf
@@ -2,6 +2,7 @@ resource "aws_security_group" "vault" {
   name_prefix = "vault_${var.project}_"
   description = "vault specific rules"
   vpc_id      = var.vpc_id
+  tags        = local.tags
 }
 
 resource "aws_security_group_rule" "vault_from_alb" {
@@ -35,6 +36,7 @@ resource "aws_security_group" "alb" {
   name        = "sg_alb_${var.project}_${var.environment}_vault"
   description = "Security group for ALB ${var.project}-${var.environment}-vault-alb"
   vpc_id      = var.vpc_id
+  tags        = local.tags
 }
 
 resource "aws_security_group_rule" "sg_alb_https_ingress" {

--- a/vault/sg.tf
+++ b/vault/sg.tf
@@ -1,7 +1,7 @@
 resource "aws_security_group" "vault" {
   name_prefix = "vault_${var.project}_"
   description = "vault specific rules"
-  vpc_id      = "${var.vpc_id}"
+  vpc_id      = var.vpc_id
 }
 
 resource "aws_security_group_rule" "vault_from_alb" {
@@ -9,8 +9,8 @@ resource "aws_security_group_rule" "vault_from_alb" {
   from_port                = 8200
   to_port                  = 8200
   protocol                 = "tcp"
-  source_security_group_id = "${module.alb.sg_id}"
-  security_group_id        = "${aws_security_group.vault.id}"
+  source_security_group_id = aws_security_group.alb.id
+  security_group_id        = aws_security_group.vault.id
 }
 
 resource "aws_security_group_rule" "vault_from_self" {
@@ -19,7 +19,7 @@ resource "aws_security_group_rule" "vault_from_self" {
   to_port           = 8201
   protocol          = "tcp"
   self              = true
-  security_group_id = "${aws_security_group.vault.id}"
+  security_group_id = aws_security_group.vault.id
 }
 
 resource "aws_security_group_rule" "vault_to_world" {
@@ -27,6 +27,30 @@ resource "aws_security_group_rule" "vault_to_world" {
   from_port         = 0
   to_port           = 0
   protocol          = "-1"
-  security_group_id = "${aws_security_group.vault.id}"
+  security_group_id = aws_security_group.vault.id
   cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group" "alb" {
+  name_prefix = "vault_alb_${var.project}_"
+  description = "Security group for Vault ALB ${var.project}-${var.environment}"
+  vpc_id      = var.vpc_id
+}
+
+resource "aws_security_group_rule" "sg_alb_https_ingress" {
+  security_group_id = aws_security_group.alb.id
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group_rule" "sg_alb_target_egress" {
+  security_group_id        = aws_security_group.alb.id
+  type                     = "egress"
+  from_port                = 8200
+  to_port                  = 8200
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.vault.id
 }

--- a/vault/sg.tf
+++ b/vault/sg.tf
@@ -32,8 +32,8 @@ resource "aws_security_group_rule" "vault_to_world" {
 }
 
 resource "aws_security_group" "alb" {
-  name_prefix = "vault_alb_${var.project}_"
-  description = "Security group for Vault ALB ${var.project}-${var.environment}"
+  name        = "sg_alb_${var.project}_${var.environment}_vault"
+  description = "Security group for ALB ${var.project}-${var.environment}-vault-alb"
   vpc_id      = var.vpc_id
 }
 

--- a/vault/variables.tf
+++ b/vault/variables.tf
@@ -103,48 +103,6 @@ variable "key_name" {
   type        = string
 }
 
-variable "enable_dynamodb_autoscaling" {
-  description = "Enables the autoscaling feature on the Vault dynamodb table"
-  default     = true
-  type        = bool
-}
-
-variable "dynamodb_max_read_capacity" {
-  description = "The max read capacity of the Vault dynamodb table"
-  default     = 100
-  type        = number
-}
-
-variable "dynamodb_min_read_capacity" {
-  description = "The min read capacity of the Vault dynamodb table"
-  default     = 5
-  type        = number
-}
-
-variable "replica_dynamodb_max_read_capacity" {
-  description = "The max read capacity of the Vault dynamodb replica table"
-  default     = 5
-  type        = number
-}
-
-variable "replica_dynamodb_min_read_capacity" {
-  description = "The min read capacity of the Vault dynamodb replica table"
-  default     = 5
-  type        = number
-}
-
-variable "dynamodb_max_write_capacity" {
-  description = "The max write capacity of the Vault dynamodb table"
-  default     = 100
-  type        = number
-}
-
-variable "dynamodb_min_write_capacity" {
-  description = "The min write capacity of the Vault dynamodb table"
-  default     = 5
-  type        = number
-}
-
 variable "dynamodb_table_name_override" {
   description = "Override Vault's DynamoDB table name with this variable. This module will generate a name if this is left empty (default behavior)"
   default     = null

--- a/vault/variables.tf
+++ b/vault/variables.tf
@@ -1,154 +1,187 @@
 variable "project" {
   description = "Name of the project"
+  type        = string
 }
 
 variable "environment" {
   description = "Name of the environment where to deploy Vault (just for naming reasons)"
+  type        = string
 }
 
 variable "lb_internal" {
   description = "Should the ALB be created as an internal Loadbalancer"
   default     = false
+  type        = bool
 }
 
 variable "dns_root" {
   description = "The root domain to configure for vault"
   default     = "production.skyscrape.rs"
+  type        = string
 }
 
 variable "vault_version" {
   description = "The Vault version to deploy"
+  type        = string
 }
 
 variable "teleport_version" {
   description = "The Teleport version to deploy"
   default     = "3.1.8"
+  type        = string
 }
 
 variable "teleport_auth_server" {
   description = "The hostname or ip of the Teleport auth server. If empty, Teleport integration will be disabled (default)."
-  default     = ""
+  default     = null
+  type        = string
 }
 
 variable "teleport_token_1" {
   description = "The Teleport token for the first instance. This can be a dynamic short-lived token"
-  default     = ""
+  default     = null
+  type        = string
 }
 
 variable "teleport_token_2" {
   description = "The Teleport token for the second instance. This can be a dynamic short-lived token"
-  default     = ""
+  default     = null
+  type        = string
 }
 
 variable "teleport_node_sg" {
   description = "The security-group ID of the teleport server"
-  default     = ""
+  default     = null
+  type        = string
 }
 
 variable "instance_type" {
   description = "The instance type to use for the vault servers"
   default     = "t2.micro"
+  type        = string
 }
 
 variable "ami" {
   description = "The AMI ID to use for the vault instances"
+  type        = string
 }
 
 variable "vault1_subnet" {
   description = "The subnet ID for the first vault instance"
+  type        = string
 }
 
 variable "vault2_subnet" {
   description = "The subnet ID for the second vault instance"
+  type        = string
 }
 
 variable "acm_arn" {
   description = "The ACM ARN to use on the alb"
+  type        = string
 }
 
 variable "vpc_id" {
   description = "The VPC id to launch the instances in"
+  type        = string
 }
 
 variable "lb_subnets" {
   description = "The subnets to use for the alb"
-  type        = "list"
+  type        = list(string)
 }
 
 variable "vault_nproc" {
   description = "The amount of nproc to configure vault with. Set this to the amount of CPU cores"
-  default     = "1"
+  default     = 1
+  type        = number
 }
 
 variable "key_name" {
   description = "Name of the sshkey to deploy on the vault instances"
+  default     = null
+  type        = string
 }
 
 variable "enable_dynamodb_autoscaling" {
   description = "Enables the autoscaling feature on the Vault dynamodb table"
-  default     = "true"
+  default     = true
+  type        = bool
 }
 
 variable "dynamodb_max_read_capacity" {
   description = "The max read capacity of the Vault dynamodb table"
-  default     = "100"
+  default     = 100
+  type        = number
 }
 
 variable "dynamodb_min_read_capacity" {
   description = "The min read capacity of the Vault dynamodb table"
-  default     = "5"
+  default     = 5
+  type        = number
 }
 
 variable "replica_dynamodb_max_read_capacity" {
   description = "The max read capacity of the Vault dynamodb replica table"
-  default     = "5"
+  default     = 5
+  type        = number
 }
 
 variable "replica_dynamodb_min_read_capacity" {
   description = "The min read capacity of the Vault dynamodb replica table"
-  default     = "5"
+  default     = 5
+  type        = number
 }
 
 variable "dynamodb_max_write_capacity" {
   description = "The max write capacity of the Vault dynamodb table"
-  default     = "100"
+  default     = 100
+  type        = number
 }
 
 variable "dynamodb_min_write_capacity" {
   description = "The min write capacity of the Vault dynamodb table"
-  default     = "5"
+  default     = 5
+  type        = number
 }
 
 variable "dynamodb_table_name_override" {
   description = "Override Vault's DynamoDB table name with this variable. This module will generate a name if this is left empty (default behavior)"
-  default     = ""
+  default     = null
+  type        = string
 }
 
 variable "acme_server" {
   description = "ACME server where to point `certbot` on the Teleport server to fetch an SSL certificate. Useful if you want to point to the letsencrypt staging server."
   default     = "https://acme-v01.api.letsencrypt.org/directory"
+  type        = string
 }
 
 variable "le_email" {
   description = "The email address that's going to be used to register to LetsEncrypt"
+  type        = string
 }
 
 variable "enable_point_in_time_recovery" {
   description = "Whether to enable point-in-time recovery - note that it can take up to 10 minutes to enable for new tables. Note that [additional charges](https://aws.amazon.com/dynamodb/pricing/) will apply by enabling this setting"
   default     = true
+  type        = bool
 }
 
 variable "enable_dynamodb_replica_table" {
   description = "Setting this to true will create a DynamoDB table on another region and enable global tables for replication. The replica table is going to be managed by the 'replica' Terraform provider"
   default     = false
+  type        = bool
 }
 
 variable "enable_ui" {
   description = "Enables the [Vault UI](https://www.vaultproject.io/docs/configuration/ui/index.html)"
   default     = true
+  type        = bool
 }
 
 variable "ec2_instances_cpu_credits" {
   description = "The type of cpu credits to use"
   default     = "standard"
+  type        = string
 }

--- a/vault/versions.tf
+++ b/vault/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
As per https://github.com/skyscrapers/engineering/issues/252

I've also switched to using alb resources directly, without an intermediate module.

This introduces breaking changes that will require a major version bump in the new release