### PR TITLE
Fix individual target groups health check

### DIFF
--- a/vault/alb.tf
+++ b/vault/alb.tf
@@ -55,7 +55,7 @@ resource "aws_lb_target_group" "vault1" {
   }
 
   health_check {
-    matcher           = "404"
+    matcher           = "200-499" # we want this target group to active as long as Vault is running, no matter its state
     protocol          = "HTTPS"
     path              = "/"
     healthy_threshold = 4
@@ -100,7 +100,7 @@ resource "aws_lb_target_group" "vault2" {
   }
 
   health_check {
-    matcher           = "404"
+    matcher           = "200-499" # we want this target group to active as long as Vault is running, no matter its state
     protocol          = "HTTPS"
     path              = "/"
     healthy_threshold = 4


### PR DESCRIPTION
Since the introduction of the Vault UI, the `/` path now returns a 307 redirect to `/ui`, instead of 404, so the health check fails.

These health checks should report OK as long as Vault it's running, regardless of its state.

However this didn't have any consequences because of this

> If a target group contains only unhealthy registered targets, the load balancer nodes route requests across its unhealthy targets.